### PR TITLE
official upstream update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if (POLICY CMP0065)
   cmake_policy(SET CMP0065 NEW)
 endif()
 
-project(TelegramBotApi VERSION 6.9.1 LANGUAGES CXX)
+project(TelegramBotApi VERSION 6.9.2 LANGUAGES CXX)
 
 if (POLICY CMP0069)
   option(TELEGRAM_BOT_API_ENABLE_LTO "Use \"ON\" to enable Link Time Optimization.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if (POLICY CMP0065)
   cmake_policy(SET CMP0065 NEW)
 endif()
 
-project(TelegramBotApi VERSION 6.8 LANGUAGES CXX)
+project(TelegramBotApi VERSION 6.9 LANGUAGES CXX)
 
 if (POLICY CMP0069)
   option(TELEGRAM_BOT_API_ENABLE_LTO "Use \"ON\" to enable Link Time Optimization.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if (POLICY CMP0065)
   cmake_policy(SET CMP0065 NEW)
 endif()
 
-project(TelegramBotApi VERSION 6.9 LANGUAGES CXX)
+project(TelegramBotApi VERSION 6.9.1 LANGUAGES CXX)
 
 if (POLICY CMP0069)
   option(TELEGRAM_BOT_API_ENABLE_LTO "Use \"ON\" to enable Link Time Optimization.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if (POLICY CMP0065)
   cmake_policy(SET CMP0065 NEW)
 endif()
 
-project(TelegramBotApi VERSION 6.7.1 LANGUAGES CXX)
+project(TelegramBotApi VERSION 6.8 LANGUAGES CXX)
 
 if (POLICY CMP0069)
   option(TELEGRAM_BOT_API_ENABLE_LTO "Use \"ON\" to enable Link Time Optimization.")

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -5874,20 +5874,8 @@ td::Result<td_api::object_ptr<td_api::labeledPricePart>> Client::get_labeled_pri
     return td::Status::Error(400, "LabeledPrice label must be non-empty");
   }
 
-  TRY_RESULT(amount, get_json_object_field(object, "amount", td::JsonValue::Type::Null, false));
-  td::Slice number;
-  if (amount.type() == td::JsonValue::Type::Number) {
-    number = amount.get_number();
-  } else if (amount.type() == td::JsonValue::Type::String) {
-    number = amount.get_string();
-  } else {
-    return td::Status::Error(400, "Field \"amount\" must be of type Number or String");
-  }
-  auto parsed_amount = td::to_integer_safe<int64>(number);
-  if (parsed_amount.is_error()) {
-    return td::Status::Error(400, "Can't parse \"amount\" as Number");
-  }
-  return make_object<td_api::labeledPricePart>(label, parsed_amount.ok());
+  TRY_RESULT(amount, get_json_object_long_field(object, "amount", false));
+  return make_object<td_api::labeledPricePart>(label, amount);
 }
 
 td::Result<td::vector<td_api::object_ptr<td_api::labeledPricePart>>> Client::get_labeled_price_parts(

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -1764,6 +1764,10 @@ class Client::JsonWriteAccessAllowed final : public td::Jsonable {
     auto object = scope->enter_object();
     if (write_access_allowed_->web_app_ != nullptr) {
       object("web_app_name", write_access_allowed_->web_app_->short_name_);
+    } else if (write_access_allowed_->by_request_) {
+      object("from_request", td::JsonTrue());
+    } else {
+      object("from_attachment_menu", td::JsonTrue());
     }
   }
 

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -2305,6 +2305,7 @@ void Client::JsonMessage::store(td::JsonValueScope *scope) const {
     case td_api::messageChatSetBackground::ID:
       break;
     case td_api::messageStory::ID:
+      object("story", JsonEmptyObject());
       break;
     default:
       UNREACHABLE();
@@ -11198,8 +11199,6 @@ bool Client::need_skip_update_message(int64 chat_id, const object_ptr<td_api::me
     case td_api::messageSuggestProfilePhoto::ID:
       return true;
     case td_api::messageChatSetBackground::ID:
-      return true;
-    case td_api::messageStory::ID:
       return true;
     default:
       break;

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -9874,7 +9874,7 @@ void Client::webhook_error(td::Status status) {
 
 void Client::webhook_closed(td::Status status) {
   if (has_webhook_certificate_) {
-    td::Scheduler::instance()->run_on_scheduler(SharedData::get_database_scheduler_id(),
+    td::Scheduler::instance()->run_on_scheduler(SharedData::get_webhook_certificate_scheduler_id(),
                                                 [actor_id = actor_id(this), path = get_webhook_certificate_path(),
                                                  status = std::move(status)](td::Unit) mutable {
                                                   LOG(INFO) << "Unlink certificate " << path;
@@ -9987,7 +9987,7 @@ void Client::do_set_webhook(PromisedQueryPtr query, bool was_deleted) {
         CHECK(!webhook_set_query_);
         active_webhook_set_query_ = std::move(query);
         td::Scheduler::instance()->run_on_scheduler(
-            SharedData::get_database_scheduler_id(),
+            SharedData::get_webhook_certificate_scheduler_id(),
             [actor_id = actor_id(this), from_path = cert_file_ptr->temp_file_name,
              to_path = get_webhook_certificate_path(), size](td::Unit) mutable {
               LOG(INFO) << "Copy certificate to " << to_path;

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -11092,6 +11092,11 @@ bool Client::need_skip_update_message(int64 chat_id, const object_ptr<td_api::me
       // don't send messages received before join or getting authorization
       return true;
     }
+
+    if (!supergroup_info->is_supergroup && message->content_->get_id() == td_api::messageSupergroupChatCreate::ID) {
+      // don't send message about channel creation, even the bot was added at exactly the same time
+      return true;
+    }
   }
 
   if (message->self_destruct_time_ > 0) {

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -7815,7 +7815,7 @@ void Client::on_message_send_failed(int64 chat_id, int64 old_message_id, int64 n
   }
 }
 
-void Client::on_cmd(PromisedQueryPtr query) {
+void Client::on_cmd(PromisedQueryPtr query, bool force) {
   LOG(DEBUG) << "Process query " << *query;
   if (!td_client_.empty() && was_authorized_) {
     if (query->method() == "close") {
@@ -7842,6 +7842,42 @@ void Client::on_cmd(PromisedQueryPtr query) {
   auto method_it = methods_.find(query->method().str());
   if (method_it == methods_.end()) {
     return fail_query(404, "Not Found: method not found", std::move(query));
+  }
+
+  if (!query->files().empty() && !parameters_->local_mode_ && !force) {
+    auto file_size = query->files_size();
+    if (file_size > 100000) {
+      auto &last_send_message_time = last_send_message_time_[file_size];
+      auto now = td::Time::now();
+      auto min_delay = td::clamp(static_cast<double>(file_size) * 1e-7, 0.2, 0.9);
+      auto max_bucket_volume = 1.0;
+      if (last_send_message_time > now + 5.0) {
+        return fail_query_flood_limit_exceeded(std::move(query));
+      }
+
+      last_send_message_time = td::max(last_send_message_time + min_delay, now - max_bucket_volume);
+      LOG(DEBUG) << "Query with files of size " << file_size << " can be processed in " << last_send_message_time - now
+                 << " seconds";
+
+      td::create_actor<td::SleepActor>(
+          "DeleteLastSendMessageTimeSleepActor", last_send_message_time + min_delay - (now - max_bucket_volume),
+          td::PromiseCreator::lambda([actor_id = actor_id(this), file_size,
+                                      max_delay = max_bucket_volume + min_delay](td::Result<td::Unit>) mutable {
+            send_closure(actor_id, &Client::delete_last_send_message_time, file_size, max_delay);
+          }))
+          .release();
+
+      if (last_send_message_time > now) {
+        td::create_actor<td::SleepActor>(
+            "DoSendMessageSleepActor", last_send_message_time - now,
+            td::PromiseCreator::lambda(
+                [actor_id = actor_id(this), query = std::move(query)](td::Result<td::Unit>) mutable {
+                  send_closure(actor_id, &Client::on_cmd, std::move(query), true);
+                }))
+            .release();
+        return;
+      }
+    }
   }
 
   auto result = (this->*(method_it->second))(query);
@@ -10027,51 +10063,6 @@ void Client::delete_last_send_message_time(td::int64 file_size, double max_delay
 
 void Client::do_send_message(object_ptr<td_api::InputMessageContent> input_message_content, PromisedQueryPtr query,
                              bool force) {
-  if (!parameters_->local_mode_) {
-    if (!force) {
-      auto file_size = query->files_size();
-      if (file_size > 100000) {
-        auto &last_send_message_time = last_send_message_time_[file_size];
-        auto now = td::Time::now();
-        auto min_delay = td::clamp(static_cast<double>(file_size) * 1e-7, 0.2, 0.9);
-        auto max_bucket_volume = 1.0;
-        if (last_send_message_time > now + 5.0) {
-          return fail_query_flood_limit_exceeded(std::move(query));
-        }
-
-        last_send_message_time = td::max(last_send_message_time + min_delay, now - max_bucket_volume);
-        LOG(DEBUG) << "Query with files of size " << file_size << " can be processed in "
-                   << last_send_message_time - now << " seconds";
-
-        td::create_actor<td::SleepActor>(
-            "DeleteLastSendMessageTimeSleepActor", last_send_message_time + min_delay - (now - max_bucket_volume),
-            td::PromiseCreator::lambda([actor_id = actor_id(this), file_size,
-                                        max_delay = max_bucket_volume + min_delay](td::Result<td::Unit>) mutable {
-              send_closure(actor_id, &Client::delete_last_send_message_time, file_size, max_delay);
-            }))
-            .release();
-
-        if (last_send_message_time > now) {
-          td::create_actor<td::SleepActor>(
-              "DoSendMessageSleepActor", last_send_message_time - now,
-              td::PromiseCreator::lambda([actor_id = actor_id(this),
-                                          input_message_content = std::move(input_message_content),
-                                          query = std::move(query)](td::Result<td::Unit>) mutable {
-                send_closure(actor_id, &Client::do_send_message, std::move(input_message_content), std::move(query),
-                             true);
-              }))
-              .release();
-          return;
-        }
-      }
-    } else {
-      if (logging_out_ || closing_) {
-        return fail_query_closing(std::move(query));
-      }
-      CHECK(was_authorized_);
-    }
-  }
-
   auto chat_id = query->arg("chat_id");
   auto message_thread_id = get_message_id(query.get(), "message_thread_id");
   auto reply_to_message_id = get_message_id(query.get(), "reply_to_message_id");

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -5015,6 +5015,7 @@ void Client::on_update_authorization_state() {
           td::reset_to_empty(pending_updates_);
         }
         last_update_creation_time_ = td::Time::now();
+        log_in_date_ = get_unix_time();
       }
       return loop();
     }
@@ -11488,7 +11489,8 @@ void Client::process_new_message_queue(int64 chat_id, int state) {
     auto now = get_unix_time();
     auto update_delay_time = now - td::max(message_date, parameters_->shared_data_->get_unix_time(webhook_set_time_));
     const auto UPDATE_DELAY_WARNING_TIME = 10 * 60;
-    if (update_delay_time > UPDATE_DELAY_WARNING_TIME && message_date > last_synchronization_error_date_ + 60) {
+    if (message_date > log_in_date_ && update_delay_time > UPDATE_DELAY_WARNING_TIME &&
+        message_date > last_synchronization_error_date_ + 60) {
       if (delayed_update_count_ == 0) {
         delayed_update_type_ = update_type;
         delayed_chat_id_ = chat_id;

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -7240,6 +7240,10 @@ td::Result<td_api::object_ptr<td_api::textEntity>> Client::get_text_entity(td::J
 
 td::Result<td_api::object_ptr<td_api::formattedText>> Client::get_formatted_text(td::string text, td::string parse_mode,
                                                                                  td::JsonValue &&input_entities) {
+  if (text.size() > (1 << 15)) {
+    return td::Status::Error(400, "Text is too long");
+  }
+
   td::to_lower_inplace(parse_mode);
   if (!text.empty() && !parse_mode.empty() && parse_mode != "none") {
     object_ptr<td_api::TextParseMode> text_parse_mode;

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -6232,6 +6232,10 @@ td::Result<td::vector<td_api::object_ptr<td_api::InputInlineQueryResult>>> Clien
   if (values.type() != td::JsonValue::Type::Array) {
     return td::Status::Error(400, "Expected an Array of inline query results");
   }
+  constexpr std::size_t MAX_INLINE_QUERY_RESULT_COUNT = 50;
+  if (values.get_array().size() > MAX_INLINE_QUERY_RESULT_COUNT) {
+    return td::Status::Error(400, "Too many inline query results specified");
+  }
 
   td::vector<object_ptr<td_api::InputInlineQueryResult>> inline_query_results;
   for (auto &value : values.get_array()) {

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -6725,11 +6725,14 @@ td::Result<td_api::object_ptr<td_api::chatAdministratorRights>> Client::get_chat
   TRY_RESULT(can_manage_topics, object.get_optional_bool_field("can_manage_topics"));
   TRY_RESULT(can_promote_members, object.get_optional_bool_field("can_promote_members"));
   TRY_RESULT(can_manage_video_chats, object.get_optional_bool_field("can_manage_video_chats"));
+  TRY_RESULT(can_post_stories, object.get_optional_bool_field("can_post_stories"));
+  TRY_RESULT(can_edit_stories, object.get_optional_bool_field("can_edit_stories"));
+  TRY_RESULT(can_delete_stories, object.get_optional_bool_field("can_delete_stories"));
   TRY_RESULT(is_anonymous, object.get_optional_bool_field("is_anonymous"));
   return make_object<td_api::chatAdministratorRights>(
       can_manage_chat, can_change_info, can_post_messages, can_edit_messages, can_delete_messages, can_invite_users,
-      can_restrict_members, can_pin_messages, can_manage_topics, can_promote_members, can_manage_video_chats, false,
-      false, false, is_anonymous);
+      can_restrict_members, can_pin_messages, can_manage_topics, can_promote_members, can_manage_video_chats,
+      can_post_stories, can_edit_stories, can_delete_stories, is_anonymous);
 }
 
 td::Result<td_api::object_ptr<td_api::chatAdministratorRights>> Client::get_chat_administrator_rights(
@@ -9159,13 +9162,16 @@ td::Status Client::process_promote_chat_member_query(PromisedQueryPtr &query) {
   auto can_promote_members = to_bool(query->arg("can_promote_members"));
   auto can_manage_video_chats =
       to_bool(query->arg("can_manage_voice_chats")) || to_bool(query->arg("can_manage_video_chats"));
+  auto can_post_stories = to_bool(query->arg("can_post_stories"));
+  auto can_edit_stories = to_bool(query->arg("can_edit_stories"));
+  auto can_delete_stories = to_bool(query->arg("can_delete_stories"));
   auto is_anonymous = to_bool(query->arg("is_anonymous"));
   auto status = make_object<td_api::chatMemberStatusAdministrator>(
       td::string(), true,
       make_object<td_api::chatAdministratorRights>(
           can_manage_chat, can_change_info, can_post_messages, can_edit_messages, can_delete_messages, can_invite_users,
-          can_restrict_members, can_pin_messages, can_manage_topics, can_promote_members, can_manage_video_chats, false,
-          false, false, is_anonymous));
+          can_restrict_members, can_pin_messages, can_manage_topics, can_promote_members, can_manage_video_chats,
+          can_post_stories, can_edit_stories, can_delete_stories, is_anonymous));
   check_chat(chat_id, AccessRights::Write, std::move(query),
              [this, user_id, status = std::move(status)](int64 chat_id, PromisedQueryPtr query) mutable {
                auto chat_info = get_chat(chat_id);
@@ -10675,6 +10681,11 @@ void Client::json_store_administrator_rights(td::JsonObjectScope &object, const 
   }
   object("can_promote_members", td::JsonBool(rights->can_promote_members_));
   object("can_manage_video_chats", td::JsonBool(rights->can_manage_video_chats_));
+  if (chat_type == ChatType::Channel) {
+    object("can_post_stories", td::JsonBool(rights->can_post_stories_));
+    object("can_edit_stories", td::JsonBool(rights->can_edit_stories_));
+    object("can_delete_stories", td::JsonBool(rights->can_delete_stories_));
+  }
   object("is_anonymous", td::JsonBool(rights->is_anonymous_));
 }
 

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -5160,14 +5160,12 @@ void Client::on_update(object_ptr<td_api::Object> result) {
       auto update = move_object_as<td_api::updateNewChat>(result);
       auto chat = std::move(update->chat_);
       auto chat_info = add_chat(chat->id_);
-      bool need_warning = false;
       switch (chat->type_->get_id()) {
         case td_api::chatTypePrivate::ID: {
           auto type = move_object_as<td_api::chatTypePrivate>(chat->type_);
           chat_info->type = ChatInfo::Type::Private;
           auto user_id = type->user_id_;
           chat_info->user_id = user_id;
-          need_warning = get_user_info(user_id) == nullptr;
           break;
         }
         case td_api::chatTypeBasicGroup::ID: {
@@ -5175,7 +5173,6 @@ void Client::on_update(object_ptr<td_api::Object> result) {
           chat_info->type = ChatInfo::Type::Group;
           auto group_id = type->basic_group_id_;
           chat_info->group_id = group_id;
-          need_warning = get_group_info(group_id) == nullptr;
           break;
         }
         case td_api::chatTypeSupergroup::ID: {
@@ -5183,7 +5180,6 @@ void Client::on_update(object_ptr<td_api::Object> result) {
           chat_info->type = ChatInfo::Type::Supergroup;
           auto supergroup_id = type->supergroup_id_;
           chat_info->supergroup_id = supergroup_id;
-          need_warning = get_supergroup_info(supergroup_id) == nullptr;
           break;
         }
         case td_api::chatTypeSecret::ID:
@@ -5191,9 +5187,6 @@ void Client::on_update(object_ptr<td_api::Object> result) {
           break;
         default:
           UNREACHABLE();
-      }
-      if (need_warning) {
-        LOG(ERROR) << "Received updateNewChat about chat " << chat->id_ << ", but hadn't received corresponding info";
       }
 
       chat_info->title = std::move(chat->title_);
@@ -10457,8 +10450,8 @@ void Client::set_group_photo(int64 group_id, object_ptr<td_api::chatPhoto> &&pho
   add_group_info(group_id)->photo = std::move(photo);
 }
 
-void Client::set_group_description(int64 group_id, td::string &&descripton) {
-  add_group_info(group_id)->description = std::move(descripton);
+void Client::set_group_description(int64 group_id, td::string &&description) {
+  add_group_info(group_id)->description = std::move(description);
 }
 
 void Client::set_group_invite_link(int64 group_id, td::string &&invite_link) {
@@ -10486,8 +10479,8 @@ void Client::set_supergroup_photo(int64 supergroup_id, object_ptr<td_api::chatPh
   add_supergroup_info(supergroup_id)->photo = std::move(photo);
 }
 
-void Client::set_supergroup_description(int64 supergroup_id, td::string &&descripton) {
-  add_supergroup_info(supergroup_id)->description = std::move(descripton);
+void Client::set_supergroup_description(int64 supergroup_id, td::string &&description) {
+  add_supergroup_info(supergroup_id)->description = std::move(description);
 }
 
 void Client::set_supergroup_invite_link(int64 supergroup_id, td::string &&invite_link) {

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -713,6 +713,9 @@ class Client::JsonChat final : public td::Jsonable {
           }
           if (user_info->emoji_status_custom_emoji_id != 0) {
             object("emoji_status_custom_emoji_id", td::to_string(user_info->emoji_status_custom_emoji_id));
+            if (user_info->emoji_status_expiration_date != 0) {
+              object("emoji_status_expiration_date", user_info->emoji_status_expiration_date);
+            }
           }
           if (!user_info->bio.empty()) {
             object("bio", user_info->bio);
@@ -10380,6 +10383,7 @@ void Client::add_user(UserInfo *user_info, object_ptr<td_api::user> &&user) {
   }
   user_info->language_code = std::move(user->language_code_);
   user_info->emoji_status_custom_emoji_id = user->emoji_status_ != nullptr ? user->emoji_status_->custom_emoji_id_ : 0;
+  user_info->emoji_status_expiration_date = user->emoji_status_ != nullptr ? user->emoji_status_->expiration_date_ : 0;
 
   user_info->have_access = user->have_access_;
   user_info->is_premium = user->is_premium_;

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -5527,26 +5527,26 @@ td::Result<td_api::object_ptr<td_api::keyboardButton>> Client::get_keyboard_butt
   if (button.type() == td::JsonValue::Type::Object) {
     auto &object = button.get_object();
 
-    TRY_RESULT(text, get_json_object_string_field(object, "text", false));
+    TRY_RESULT(text, object.get_required_string_field("text"));
 
-    TRY_RESULT(request_phone_number, get_json_object_bool_field(object, "request_phone_number"));
-    TRY_RESULT(request_contact, get_json_object_bool_field(object, "request_contact"));
+    TRY_RESULT(request_phone_number, object.get_optional_bool_field("request_phone_number"));
+    TRY_RESULT(request_contact, object.get_optional_bool_field("request_contact"));
     if (request_phone_number || request_contact) {
       return make_object<td_api::keyboardButton>(text, make_object<td_api::keyboardButtonTypeRequestPhoneNumber>());
     }
 
-    TRY_RESULT(request_location, get_json_object_bool_field(object, "request_location"));
+    TRY_RESULT(request_location, object.get_optional_bool_field("request_location"));
     if (request_location) {
       return make_object<td_api::keyboardButton>(text, make_object<td_api::keyboardButtonTypeRequestLocation>());
     }
 
-    if (has_json_object_field(object, "request_poll")) {
+    if (object.has_field("request_poll")) {
       bool force_regular = false;
       bool force_quiz = false;
-      TRY_RESULT(request_poll, get_json_object_field(object, "request_poll", td::JsonValue::Type::Object, false));
+      TRY_RESULT(request_poll, object.extract_required_field("request_poll", td::JsonValue::Type::Object));
       auto &request_poll_object = request_poll.get_object();
-      if (has_json_object_field(request_poll_object, "type")) {
-        TRY_RESULT(type, get_json_object_string_field(request_poll_object, "type"));
+      if (request_poll_object.has_field("type")) {
+        TRY_RESULT(type, request_poll_object.get_optional_string_field("type"));
         if (type == "quiz") {
           force_quiz = true;
         } else if (type == "regular") {
@@ -5557,47 +5557,48 @@ td::Result<td_api::object_ptr<td_api::keyboardButton>> Client::get_keyboard_butt
           text, make_object<td_api::keyboardButtonTypeRequestPoll>(force_regular, force_quiz));
     }
 
-    if (has_json_object_field(object, "web_app")) {
-      TRY_RESULT(web_app, get_json_object_field(object, "web_app", td::JsonValue::Type::Object, false));
+    if (object.has_field("web_app")) {
+      TRY_RESULT(web_app, object.extract_required_field("web_app", td::JsonValue::Type::Object));
       auto &web_app_object = web_app.get_object();
-      TRY_RESULT(url, get_json_object_string_field(web_app_object, "url", false));
+      TRY_RESULT(url, web_app_object.get_required_string_field("url"));
       return make_object<td_api::keyboardButton>(text, make_object<td_api::keyboardButtonTypeWebApp>(url));
     }
 
-    if (has_json_object_field(object, "request_user")) {
-      TRY_RESULT(request_user, get_json_object_field(object, "request_user", td::JsonValue::Type::Object, false));
+    if (object.has_field("request_user")) {
+      TRY_RESULT(request_user, object.extract_required_field("request_user", td::JsonValue::Type::Object));
       auto &request_user_object = request_user.get_object();
-      TRY_RESULT(id, get_json_object_int_field(request_user_object, "request_id", false));
-      auto restrict_user_is_bot = has_json_object_field(request_user_object, "user_is_bot");
-      TRY_RESULT(user_is_bot, get_json_object_bool_field(request_user_object, "user_is_bot"));
-      auto restrict_user_is_premium = has_json_object_field(request_user_object, "user_is_premium");
-      TRY_RESULT(user_is_premium, get_json_object_bool_field(request_user_object, "user_is_premium"));
+      TRY_RESULT(id, request_user_object.get_required_int_field("request_id"));
+      auto restrict_user_is_bot = request_user_object.has_field("user_is_bot");
+      TRY_RESULT(user_is_bot, request_user_object.get_optional_bool_field("user_is_bot"));
+      auto restrict_user_is_premium = request_user_object.has_field("user_is_premium");
+      TRY_RESULT(user_is_premium, request_user_object.get_optional_bool_field("user_is_premium"));
       return make_object<td_api::keyboardButton>(
           text, make_object<td_api::keyboardButtonTypeRequestUser>(id, restrict_user_is_bot, user_is_bot,
                                                                    restrict_user_is_premium, user_is_premium));
     }
 
-    if (has_json_object_field(object, "request_chat")) {
-      TRY_RESULT(request_chat, get_json_object_field(object, "request_chat", td::JsonValue::Type::Object, false));
+    if (object.has_field("request_chat")) {
+      TRY_RESULT(request_chat, object.extract_required_field("request_chat", td::JsonValue::Type::Object));
       auto &request_chat_object = request_chat.get_object();
-      TRY_RESULT(id, get_json_object_int_field(request_chat_object, "request_id", false));
-      TRY_RESULT(chat_is_channel, get_json_object_bool_field(request_chat_object, "chat_is_channel"));
-      auto restrict_chat_is_forum = has_json_object_field(request_chat_object, "chat_is_forum");
-      TRY_RESULT(chat_is_forum, get_json_object_bool_field(request_chat_object, "chat_is_forum"));
-      auto restrict_chat_has_username = has_json_object_field(request_chat_object, "chat_has_username");
-      TRY_RESULT(chat_has_username, get_json_object_bool_field(request_chat_object, "chat_has_username"));
-      TRY_RESULT(chat_is_created, get_json_object_bool_field(request_chat_object, "chat_is_created"));
+      TRY_RESULT(id, request_chat_object.get_required_int_field("request_id"));
+      TRY_RESULT(chat_is_channel, request_chat_object.get_optional_bool_field("chat_is_channel"));
+      auto restrict_chat_is_forum = request_chat_object.has_field("chat_is_forum");
+      TRY_RESULT(chat_is_forum, request_chat_object.get_optional_bool_field("chat_is_forum"));
+      auto restrict_chat_has_username = request_chat_object.has_field("chat_has_username");
+      TRY_RESULT(chat_has_username, request_chat_object.get_optional_bool_field("chat_has_username"));
+      TRY_RESULT(chat_is_created, request_chat_object.get_optional_bool_field("chat_is_created"));
       object_ptr<td_api::chatAdministratorRights> user_administrator_rights;
-      if (has_json_object_field(request_chat_object, "user_administrator_rights")) {
-        TRY_RESULT_ASSIGN(user_administrator_rights, get_chat_administrator_rights(get_json_object_field_force(
-                                                         request_chat_object, "user_administrator_rights")));
+      if (request_chat_object.has_field("user_administrator_rights")) {
+        TRY_RESULT_ASSIGN(
+            user_administrator_rights,
+            get_chat_administrator_rights(request_chat_object.extract_field("user_administrator_rights")));
       }
       object_ptr<td_api::chatAdministratorRights> bot_administrator_rights;
-      if (has_json_object_field(request_chat_object, "bot_administrator_rights")) {
-        TRY_RESULT_ASSIGN(bot_administrator_rights, get_chat_administrator_rights(get_json_object_field_force(
-                                                        request_chat_object, "bot_administrator_rights")));
+      if (request_chat_object.has_field("bot_administrator_rights")) {
+        TRY_RESULT_ASSIGN(bot_administrator_rights,
+                          get_chat_administrator_rights(request_chat_object.extract_field("bot_administrator_rights")));
       }
-      TRY_RESULT(bot_is_member, get_json_object_bool_field(request_chat_object, "bot_is_member"));
+      TRY_RESULT(bot_is_member, request_chat_object.get_optional_bool_field("bot_is_member"));
       return make_object<td_api::keyboardButton>(
           text, make_object<td_api::keyboardButtonTypeRequestChat>(
                     id, chat_is_channel, restrict_chat_is_forum, chat_is_forum, restrict_chat_has_username,
@@ -5622,68 +5623,68 @@ td::Result<td_api::object_ptr<td_api::inlineKeyboardButton>> Client::get_inline_
 
   auto &object = button.get_object();
 
-  TRY_RESULT(text, get_json_object_string_field(object, "text", false));
+  TRY_RESULT(text, object.get_required_string_field("text"));
   {
-    TRY_RESULT(url, get_json_object_string_field(object, "url"));
+    TRY_RESULT(url, object.get_optional_string_field("url"));
     if (!url.empty()) {
       return make_object<td_api::inlineKeyboardButton>(text, make_object<td_api::inlineKeyboardButtonTypeUrl>(url));
     }
   }
 
   {
-    TRY_RESULT(callback_data, get_json_object_string_field(object, "callback_data"));
+    TRY_RESULT(callback_data, object.get_optional_string_field("callback_data"));
     if (!callback_data.empty()) {
       return make_object<td_api::inlineKeyboardButton>(
           text, make_object<td_api::inlineKeyboardButtonTypeCallback>(callback_data));
     }
   }
 
-  if (has_json_object_field(object, "callback_game")) {
+  if (object.has_field("callback_game")) {
     return make_object<td_api::inlineKeyboardButton>(text, make_object<td_api::inlineKeyboardButtonTypeCallbackGame>());
   }
 
-  if (has_json_object_field(object, "pay")) {
+  if (object.has_field("pay")) {
     return make_object<td_api::inlineKeyboardButton>(text, make_object<td_api::inlineKeyboardButtonTypeBuy>());
   }
 
-  if (has_json_object_field(object, "switch_inline_query")) {
-    TRY_RESULT(switch_inline_query, get_json_object_string_field(object, "switch_inline_query", false));
+  if (object.has_field("switch_inline_query")) {
+    TRY_RESULT(switch_inline_query, object.get_required_string_field("switch_inline_query"));
     return make_object<td_api::inlineKeyboardButton>(
         text, make_object<td_api::inlineKeyboardButtonTypeSwitchInline>(
                   switch_inline_query, td_api::make_object<td_api::targetChatChosen>(true, true, true, true)));
   }
 
-  if (has_json_object_field(object, "switch_inline_query_chosen_chat")) {
+  if (object.has_field("switch_inline_query_chosen_chat")) {
     TRY_RESULT(switch_inline_query,
-               get_json_object_field(object, "switch_inline_query_chosen_chat", td::JsonValue::Type::Object, false));
+               object.extract_required_field("switch_inline_query_chosen_chat", td::JsonValue::Type::Object));
     CHECK(switch_inline_query.type() == td::JsonValue::Type::Object);
     auto &switch_inline_query_object = switch_inline_query.get_object();
-    TRY_RESULT(query, get_json_object_string_field(switch_inline_query_object, "query"));
-    TRY_RESULT(allow_user_chats, get_json_object_bool_field(switch_inline_query_object, "allow_user_chats"));
-    TRY_RESULT(allow_bot_chats, get_json_object_bool_field(switch_inline_query_object, "allow_bot_chats"));
-    TRY_RESULT(allow_group_chats, get_json_object_bool_field(switch_inline_query_object, "allow_group_chats"));
-    TRY_RESULT(allow_channel_chats, get_json_object_bool_field(switch_inline_query_object, "allow_channel_chats"));
+    TRY_RESULT(query, switch_inline_query_object.get_optional_string_field("query"));
+    TRY_RESULT(allow_user_chats, switch_inline_query_object.get_optional_bool_field("allow_user_chats"));
+    TRY_RESULT(allow_bot_chats, switch_inline_query_object.get_optional_bool_field("allow_bot_chats"));
+    TRY_RESULT(allow_group_chats, switch_inline_query_object.get_optional_bool_field("allow_group_chats"));
+    TRY_RESULT(allow_channel_chats, switch_inline_query_object.get_optional_bool_field("allow_channel_chats"));
     return make_object<td_api::inlineKeyboardButton>(
         text, make_object<td_api::inlineKeyboardButtonTypeSwitchInline>(
                   query, td_api::make_object<td_api::targetChatChosen>(allow_user_chats, allow_bot_chats,
                                                                        allow_group_chats, allow_channel_chats)));
   }
 
-  if (has_json_object_field(object, "switch_inline_query_current_chat")) {
-    TRY_RESULT(switch_inline_query, get_json_object_string_field(object, "switch_inline_query_current_chat", false));
+  if (object.has_field("switch_inline_query_current_chat")) {
+    TRY_RESULT(switch_inline_query, object.get_required_string_field("switch_inline_query_current_chat"));
     return make_object<td_api::inlineKeyboardButton>(
         text, make_object<td_api::inlineKeyboardButtonTypeSwitchInline>(
                   switch_inline_query, td_api::make_object<td_api::targetChatCurrent>()));
   }
 
-  if (has_json_object_field(object, "login_url")) {
-    TRY_RESULT(login_url, get_json_object_field(object, "login_url", td::JsonValue::Type::Object, false));
+  if (object.has_field("login_url")) {
+    TRY_RESULT(login_url, object.extract_required_field("login_url", td::JsonValue::Type::Object));
     CHECK(login_url.type() == td::JsonValue::Type::Object);
     auto &login_url_object = login_url.get_object();
-    TRY_RESULT(url, get_json_object_string_field(login_url_object, "url", false));
-    TRY_RESULT(bot_username, get_json_object_string_field(login_url_object, "bot_username"));
-    TRY_RESULT(request_write_access, get_json_object_bool_field(login_url_object, "request_write_access"));
-    TRY_RESULT(forward_text, get_json_object_string_field(login_url_object, "forward_text"));
+    TRY_RESULT(url, login_url_object.get_required_string_field("url"));
+    TRY_RESULT(bot_username, login_url_object.get_optional_string_field("bot_username"));
+    TRY_RESULT(request_write_access, login_url_object.get_optional_bool_field("request_write_access"));
+    TRY_RESULT(forward_text, login_url_object.get_optional_string_field("forward_text"));
 
     int64 bot_user_id = 0;
     if (bot_username.empty()) {
@@ -5717,10 +5718,10 @@ td::Result<td_api::object_ptr<td_api::inlineKeyboardButton>> Client::get_inline_
         text, make_object<td_api::inlineKeyboardButtonTypeLoginUrl>(url, bot_user_id, forward_text));
   }
 
-  if (has_json_object_field(object, "web_app")) {
-    TRY_RESULT(web_app, get_json_object_field(object, "web_app", td::JsonValue::Type::Object, false));
+  if (object.has_field("web_app")) {
+    TRY_RESULT(web_app, object.extract_required_field("web_app", td::JsonValue::Type::Object));
     auto &web_app_object = web_app.get_object();
-    TRY_RESULT(url, get_json_object_string_field(web_app_object, "url", false));
+    TRY_RESULT(url, web_app_object.get_required_string_field("url"));
     return make_object<td_api::inlineKeyboardButton>(text, make_object<td_api::inlineKeyboardButtonTypeWebApp>(url));
   }
 
@@ -5869,12 +5870,12 @@ td::Result<td_api::object_ptr<td_api::labeledPricePart>> Client::get_labeled_pri
 
   auto &object = value.get_object();
 
-  TRY_RESULT(label, get_json_object_string_field(object, "label", false));
+  TRY_RESULT(label, object.get_required_string_field("label"));
   if (label.empty()) {
     return td::Status::Error(400, "LabeledPrice label must be non-empty");
   }
 
-  TRY_RESULT(amount, get_json_object_long_field(object, "amount", false));
+  TRY_RESULT(amount, object.get_required_long_field("amount"));
   return make_object<td_api::labeledPricePart>(label, amount);
 }
 
@@ -5930,17 +5931,17 @@ td::Result<td_api::object_ptr<td_api::shippingOption>> Client::get_shipping_opti
 
   auto &object = option.get_object();
 
-  TRY_RESULT(id, get_json_object_string_field(object, "id", false));
+  TRY_RESULT(id, object.get_required_string_field("id"));
   if (id.empty()) {
     return td::Status::Error(400, "ShippingOption identifier must be non-empty");
   }
 
-  TRY_RESULT(title, get_json_object_string_field(object, "title", false));
+  TRY_RESULT(title, object.get_required_string_field("title"));
   if (title.empty()) {
     return td::Status::Error(400, "ShippingOption title must be non-empty");
   }
 
-  TRY_RESULT(prices_json, get_json_object_field(object, "prices", td::JsonValue::Type::Array, false));
+  TRY_RESULT(prices_json, object.extract_required_field("prices", td::JsonValue::Type::Array));
 
   auto r_prices = get_labeled_price_parts(prices_json);
   if (r_prices.is_error()) {
@@ -6087,42 +6088,42 @@ td::Result<td_api::object_ptr<td_api::InputMessageContent>> Client::get_input_me
   CHECK(input_message_content.type() == td::JsonValue::Type::Object);
   auto &object = input_message_content.get_object();
 
-  TRY_RESULT(message_text, get_json_object_string_field(object, "message_text"));
+  TRY_RESULT(message_text, object.get_optional_string_field("message_text"));
 
   if (!message_text.empty()) {
-    TRY_RESULT(disable_web_page_preview, get_json_object_bool_field(object, "disable_web_page_preview"));
-    TRY_RESULT(parse_mode, get_json_object_string_field(object, "parse_mode"));
-    auto entities = get_json_object_field_force(object, "entities");
+    TRY_RESULT(disable_web_page_preview, object.get_optional_bool_field("disable_web_page_preview"));
+    TRY_RESULT(parse_mode, object.get_optional_string_field("parse_mode"));
+    auto entities = object.extract_field("entities");
     TRY_RESULT(input_message_text, get_input_message_text(std::move(message_text), disable_web_page_preview,
                                                           std::move(parse_mode), std::move(entities)));
     return std::move(input_message_text);
   }
 
-  if (has_json_object_field(object, "latitude") && has_json_object_field(object, "longitude")) {
-    TRY_RESULT(latitude, get_json_object_double_field(object, "latitude", false));
-    TRY_RESULT(longitude, get_json_object_double_field(object, "longitude", false));
-    TRY_RESULT(horizontal_accuracy, get_json_object_double_field(object, "horizontal_accuracy"));
-    TRY_RESULT(live_period, get_json_object_int_field(object, "live_period"));
-    TRY_RESULT(heading, get_json_object_int_field(object, "heading"));
-    TRY_RESULT(proximity_alert_radius, get_json_object_int_field(object, "proximity_alert_radius"));
+  if (object.has_field("latitude") && object.has_field("longitude")) {
+    TRY_RESULT(latitude, object.get_required_double_field("latitude"));
+    TRY_RESULT(longitude, object.get_required_double_field("longitude"));
+    TRY_RESULT(horizontal_accuracy, object.get_optional_double_field("horizontal_accuracy"));
+    TRY_RESULT(live_period, object.get_optional_int_field("live_period"));
+    TRY_RESULT(heading, object.get_optional_int_field("heading"));
+    TRY_RESULT(proximity_alert_radius, object.get_optional_int_field("proximity_alert_radius"));
     auto location = make_object<td_api::location>(latitude, longitude, horizontal_accuracy);
 
-    if (has_json_object_field(object, "title") && has_json_object_field(object, "address")) {
-      TRY_RESULT(title, get_json_object_string_field(object, "title", false));
-      TRY_RESULT(address, get_json_object_string_field(object, "address", false));
+    if (object.has_field("title") && object.has_field("address")) {
+      TRY_RESULT(title, object.get_required_string_field("title"));
+      TRY_RESULT(address, object.get_required_string_field("address"));
       td::string provider;
       td::string venue_id;
       td::string venue_type;
 
-      TRY_RESULT(google_place_id, get_json_object_string_field(object, "google_place_id"));
-      TRY_RESULT(google_place_type, get_json_object_string_field(object, "google_place_type"));
+      TRY_RESULT(google_place_id, object.get_optional_string_field("google_place_id"));
+      TRY_RESULT(google_place_type, object.get_optional_string_field("google_place_type"));
       if (!google_place_id.empty() || !google_place_type.empty()) {
         provider = "gplaces";
         venue_id = std::move(google_place_id);
         venue_type = std::move(google_place_type);
       }
-      TRY_RESULT(foursquare_id, get_json_object_string_field(object, "foursquare_id"));
-      TRY_RESULT(foursquare_type, get_json_object_string_field(object, "foursquare_type"));
+      TRY_RESULT(foursquare_id, object.get_optional_string_field("foursquare_id"));
+      TRY_RESULT(foursquare_type, object.get_optional_string_field("foursquare_type"));
       if (!foursquare_id.empty() || !foursquare_type.empty()) {
         provider = "foursquare";
         venue_id = std::move(foursquare_id);
@@ -6136,46 +6137,46 @@ td::Result<td_api::object_ptr<td_api::InputMessageContent>> Client::get_input_me
     return make_object<td_api::inputMessageLocation>(std::move(location), live_period, heading, proximity_alert_radius);
   }
 
-  if (has_json_object_field(object, "phone_number")) {
-    TRY_RESULT(phone_number, get_json_object_string_field(object, "phone_number", false));
-    TRY_RESULT(first_name, get_json_object_string_field(object, "first_name", false));
-    TRY_RESULT(last_name, get_json_object_string_field(object, "last_name"));
-    TRY_RESULT(vcard, get_json_object_string_field(object, "vcard"));
+  if (object.has_field("phone_number")) {
+    TRY_RESULT(phone_number, object.get_required_string_field("phone_number"));
+    TRY_RESULT(first_name, object.get_required_string_field("first_name"));
+    TRY_RESULT(last_name, object.get_optional_string_field("last_name"));
+    TRY_RESULT(vcard, object.get_optional_string_field("vcard"));
 
     return make_object<td_api::inputMessageContact>(
         make_object<td_api::contact>(phone_number, first_name, last_name, vcard, 0));
   }
 
-  if (has_json_object_field(object, "payload")) {
-    TRY_RESULT(title, get_json_object_string_field(object, "title", false));
-    TRY_RESULT(description, get_json_object_string_field(object, "description", false));
-    TRY_RESULT(payload, get_json_object_string_field(object, "payload", false));
+  if (object.has_field("payload")) {
+    TRY_RESULT(title, object.get_required_string_field("title"));
+    TRY_RESULT(description, object.get_required_string_field("description"));
+    TRY_RESULT(payload, object.get_required_string_field("payload"));
     if (!td::check_utf8(payload)) {
       return td::Status::Error(400, "InputInvoiceMessageContent payload must be encoded in UTF-8");
     }
-    TRY_RESULT(provider_token, get_json_object_string_field(object, "provider_token", false));
-    TRY_RESULT(currency, get_json_object_string_field(object, "currency", false));
-    TRY_RESULT(prices_object, get_json_object_field(object, "prices", td::JsonValue::Type::Array, false));
+    TRY_RESULT(provider_token, object.get_required_string_field("provider_token"));
+    TRY_RESULT(currency, object.get_required_string_field("currency"));
+    TRY_RESULT(prices_object, object.extract_required_field("prices", td::JsonValue::Type::Array));
     TRY_RESULT(prices, get_labeled_price_parts(prices_object));
-    TRY_RESULT(provider_data, get_json_object_string_field(object, "provider_data"));
-    TRY_RESULT(max_tip_amount, get_json_object_long_field(object, "max_tip_amount"));
+    TRY_RESULT(provider_data, object.get_optional_string_field("provider_data"));
+    TRY_RESULT(max_tip_amount, object.get_optional_long_field("max_tip_amount"));
     td::vector<int64> suggested_tip_amounts;
     TRY_RESULT(suggested_tip_amounts_array,
-               get_json_object_field(object, "suggested_tip_amounts", td::JsonValue::Type::Array));
+               object.extract_optional_field("suggested_tip_amounts", td::JsonValue::Type::Array));
     if (suggested_tip_amounts_array.type() == td::JsonValue::Type::Array) {
       TRY_RESULT_ASSIGN(suggested_tip_amounts, get_suggested_tip_amounts(suggested_tip_amounts_array));
     }
-    TRY_RESULT(photo_url, get_json_object_string_field(object, "photo_url"));
-    TRY_RESULT(photo_size, get_json_object_int_field(object, "photo_size"));
-    TRY_RESULT(photo_width, get_json_object_int_field(object, "photo_width"));
-    TRY_RESULT(photo_height, get_json_object_int_field(object, "photo_height"));
-    TRY_RESULT(need_name, get_json_object_bool_field(object, "need_name"));
-    TRY_RESULT(need_phone_number, get_json_object_bool_field(object, "need_phone_number"));
-    TRY_RESULT(need_email_address, get_json_object_bool_field(object, "need_email"));
-    TRY_RESULT(need_shipping_address, get_json_object_bool_field(object, "need_shipping_address"));
-    TRY_RESULT(send_phone_number_to_provider, get_json_object_bool_field(object, "send_phone_number_to_provider"));
-    TRY_RESULT(send_email_address_to_provider, get_json_object_bool_field(object, "send_email_to_provider"));
-    TRY_RESULT(is_flexible, get_json_object_bool_field(object, "is_flexible"));
+    TRY_RESULT(photo_url, object.get_optional_string_field("photo_url"));
+    TRY_RESULT(photo_size, object.get_optional_int_field("photo_size"));
+    TRY_RESULT(photo_width, object.get_optional_int_field("photo_width"));
+    TRY_RESULT(photo_height, object.get_optional_int_field("photo_height"));
+    TRY_RESULT(need_name, object.get_optional_bool_field("need_name"));
+    TRY_RESULT(need_phone_number, object.get_optional_bool_field("need_phone_number"));
+    TRY_RESULT(need_email_address, object.get_optional_bool_field("need_email"));
+    TRY_RESULT(need_shipping_address, object.get_optional_bool_field("need_shipping_address"));
+    TRY_RESULT(send_phone_number_to_provider, object.get_optional_bool_field("send_phone_number_to_provider"));
+    TRY_RESULT(send_email_address_to_provider, object.get_optional_bool_field("send_email_to_provider"));
+    TRY_RESULT(is_flexible, object.get_optional_bool_field("is_flexible"));
 
     return make_object<td_api::inputMessageInvoice>(
         make_object<td_api::invoice>(currency, std::move(prices), max_tip_amount, std::move(suggested_tip_amounts),
@@ -6205,18 +6206,18 @@ td::Result<td_api::object_ptr<td_api::inlineQueryResultsButton>> Client::get_inl
 
   auto &object = value.get_object();
 
-  TRY_RESULT(text, get_json_object_string_field(object, "text", false));
+  TRY_RESULT(text, object.get_required_string_field("text"));
 
-  if (has_json_object_field(object, "start_parameter")) {
-    TRY_RESULT(start_parameter, get_json_object_string_field(object, "start_parameter", false));
+  if (object.has_field("start_parameter")) {
+    TRY_RESULT(start_parameter, object.get_required_string_field("start_parameter"));
     return make_object<td_api::inlineQueryResultsButton>(
         text, make_object<td_api::inlineQueryResultsButtonTypeStartBot>(start_parameter));
   }
 
-  if (has_json_object_field(object, "web_app")) {
-    TRY_RESULT(web_app, get_json_object_field(object, "web_app", td::JsonValue::Type::Object, false));
+  if (object.has_field("web_app")) {
+    TRY_RESULT(web_app, object.extract_required_field("web_app", td::JsonValue::Type::Object));
     auto &web_app_object = web_app.get_object();
-    TRY_RESULT(url, get_json_object_string_field(web_app_object, "url", false));
+    TRY_RESULT(url, web_app_object.get_required_string_field("url"));
     return make_object<td_api::inlineQueryResultsButton>(text,
                                                          make_object<td_api::inlineQueryResultsButtonTypeWebApp>(url));
   }
@@ -6309,21 +6310,22 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
 
   auto &object = value.get_object();
 
-  TRY_RESULT(type, get_json_object_string_field(object, "type", false));
+  TRY_RESULT(type, object.get_required_string_field("type"));
   td::to_lower_inplace(type);
 
-  TRY_RESULT(id, get_json_object_string_field(object, "id", false));
+  TRY_RESULT(id, object.get_required_string_field("id"));
 
   bool is_input_message_content_required = (type == "article");
   object_ptr<td_api::InputMessageContent> input_message_content;
 
   TRY_RESULT(input_message_content_obj,
-             get_json_object_field(object, "input_message_content", td::JsonValue::Type::Object));
+             object.extract_optional_field("input_message_content", td::JsonValue::Type::Object));
   if (input_message_content_obj.type() == td::JsonValue::Type::Null) {
-    TRY_RESULT(message_text, get_json_object_string_field(object, "message_text", !is_input_message_content_required));
-    TRY_RESULT(disable_web_page_preview, get_json_object_bool_field(object, "disable_web_page_preview"));
-    TRY_RESULT(parse_mode, get_json_object_string_field(object, "parse_mode"));
-    auto entities = get_json_object_field_force(object, "entities");
+    TRY_RESULT(message_text, is_input_message_content_required ? object.get_required_string_field("message_text")
+                                                               : object.get_optional_string_field("message_text"));
+    TRY_RESULT(disable_web_page_preview, object.get_optional_bool_field("disable_web_page_preview"));
+    TRY_RESULT(parse_mode, object.get_optional_string_field("parse_mode"));
+    auto entities = object.extract_field("entities");
 
     if (is_input_message_content_required || !message_text.empty()) {
       TRY_RESULT(input_message_text, get_input_message_text(std::move(message_text), disable_web_page_preview,
@@ -6335,12 +6337,12 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
                get_input_message_content(input_message_content_obj, is_input_message_content_required));
     input_message_content = std::move(input_message_content_result);
   }
-  TRY_RESULT(input_caption, get_json_object_string_field(object, "caption"));
-  TRY_RESULT(parse_mode, get_json_object_string_field(object, "parse_mode"));
-  auto entities = get_json_object_field_force(object, "caption_entities");
+  TRY_RESULT(input_caption, object.get_optional_string_field("caption"));
+  TRY_RESULT(parse_mode, object.get_optional_string_field("parse_mode"));
+  auto entities = object.extract_field("caption_entities");
   TRY_RESULT(caption, get_formatted_text(std::move(input_caption), std::move(parse_mode), std::move(entities)));
 
-  TRY_RESULT(reply_markup_object, get_json_object_field(object, "reply_markup", td::JsonValue::Type::Object));
+  TRY_RESULT(reply_markup_object, object.extract_optional_field("reply_markup", td::JsonValue::Type::Object));
   object_ptr<td_api::ReplyMarkup> reply_markup;
   if (reply_markup_object.type() != td::JsonValue::Type::Null) {
     TRY_RESULT_ASSIGN(reply_markup, get_reply_markup(std::move(reply_markup_object), bot_user_ids));
@@ -6349,23 +6351,22 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
   auto thumbnail_url_field_name = td::Slice("thumbnail_url");
   auto thumbnail_width_field_name = td::Slice("thumbnail_width");
   auto thumbnail_height_field_name = td::Slice("thumbnail_height");
-  if (!has_json_object_field(object, thumbnail_url_field_name) &&
-      !has_json_object_field(object, thumbnail_width_field_name) &&
-      !has_json_object_field(object, thumbnail_height_field_name)) {
+  if (!object.has_field(thumbnail_url_field_name) && !object.has_field(thumbnail_width_field_name) &&
+      !object.has_field(thumbnail_height_field_name)) {
     thumbnail_url_field_name = td::Slice("thumb_url");
     thumbnail_width_field_name = td::Slice("thumb_width");
     thumbnail_height_field_name = td::Slice("thumb_height");
   }
-  TRY_RESULT(thumbnail_url, get_json_object_string_field(object, thumbnail_url_field_name));
-  TRY_RESULT(thumbnail_width, get_json_object_int_field(object, thumbnail_width_field_name));
-  TRY_RESULT(thumbnail_height, get_json_object_int_field(object, thumbnail_height_field_name));
+  TRY_RESULT(thumbnail_url, object.get_optional_string_field(thumbnail_url_field_name));
+  TRY_RESULT(thumbnail_width, object.get_optional_int_field(thumbnail_width_field_name));
+  TRY_RESULT(thumbnail_height, object.get_optional_int_field(thumbnail_height_field_name));
 
   object_ptr<td_api::InputInlineQueryResult> result;
   if (type == "article") {
-    TRY_RESULT(url, get_json_object_string_field(object, "url"));
-    TRY_RESULT(hide_url, get_json_object_bool_field(object, "hide_url"));
-    TRY_RESULT(title, get_json_object_string_field(object, "title", false));
-    TRY_RESULT(description, get_json_object_string_field(object, "description"));
+    TRY_RESULT(url, object.get_optional_string_field("url"));
+    TRY_RESULT(hide_url, object.get_optional_bool_field("hide_url"));
+    TRY_RESULT(title, object.get_required_string_field("title"));
+    TRY_RESULT(description, object.get_optional_string_field("description"));
 
     CHECK(input_message_content != nullptr);
     return make_object<td_api::inputInlineQueryResultArticle>(
@@ -6373,12 +6374,13 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
         std::move(reply_markup), std::move(input_message_content));
   }
   if (type == "audio") {
-    TRY_RESULT(audio_url, get_json_object_string_field(object, "audio_url"));
-    TRY_RESULT(audio_duration, get_json_object_int_field(object, "audio_duration"));
-    TRY_RESULT(title, get_json_object_string_field(object, "title", audio_url.empty()));
-    TRY_RESULT(performer, get_json_object_string_field(object, "performer"));
+    TRY_RESULT(audio_url, object.get_optional_string_field("audio_url"));
+    TRY_RESULT(audio_duration, object.get_optional_int_field("audio_duration"));
+    TRY_RESULT(title, audio_url.empty() ? object.get_optional_string_field("title")
+                                        : object.get_required_string_field("title"));
+    TRY_RESULT(performer, object.get_optional_string_field("performer"));
     if (audio_url.empty()) {
-      TRY_RESULT_ASSIGN(audio_url, get_json_object_string_field(object, "audio_file_id", false));
+      TRY_RESULT_ASSIGN(audio_url, object.get_required_string_field("audio_file_id"));
     }
 
     if (input_message_content == nullptr) {
@@ -6389,10 +6391,10 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
                                                             std::move(reply_markup), std::move(input_message_content));
   }
   if (type == "contact") {
-    TRY_RESULT(phone_number, get_json_object_string_field(object, "phone_number", false));
-    TRY_RESULT(first_name, get_json_object_string_field(object, "first_name", false));
-    TRY_RESULT(last_name, get_json_object_string_field(object, "last_name"));
-    TRY_RESULT(vcard, get_json_object_string_field(object, "vcard"));
+    TRY_RESULT(phone_number, object.get_required_string_field("phone_number"));
+    TRY_RESULT(first_name, object.get_required_string_field("first_name"));
+    TRY_RESULT(last_name, object.get_optional_string_field("last_name"));
+    TRY_RESULT(vcard, object.get_optional_string_field("vcard"));
 
     if (input_message_content == nullptr) {
       input_message_content = make_object<td_api::inputMessageContact>(
@@ -6403,12 +6405,13 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
         thumbnail_height, std::move(reply_markup), std::move(input_message_content));
   }
   if (type == "document") {
-    TRY_RESULT(title, get_json_object_string_field(object, "title", false));
-    TRY_RESULT(description, get_json_object_string_field(object, "description"));
-    TRY_RESULT(document_url, get_json_object_string_field(object, "document_url"));
-    TRY_RESULT(mime_type, get_json_object_string_field(object, "mime_type", document_url.empty()));
+    TRY_RESULT(title, object.get_required_string_field("title"));
+    TRY_RESULT(description, object.get_optional_string_field("description"));
+    TRY_RESULT(document_url, object.get_optional_string_field("document_url"));
+    TRY_RESULT(mime_type, document_url.empty() ? object.get_optional_string_field("mime_type")
+                                               : object.get_required_string_field("mime_type"));
     if (document_url.empty()) {
-      TRY_RESULT_ASSIGN(document_url, get_json_object_string_field(object, "document_file_id", false));
+      TRY_RESULT_ASSIGN(document_url, object.get_required_string_field("document_file_id"));
     }
 
     if (input_message_content == nullptr) {
@@ -6419,22 +6422,22 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
         std::move(reply_markup), std::move(input_message_content));
   }
   if (type == "game") {
-    TRY_RESULT(game_short_name, get_json_object_string_field(object, "game_short_name", false));
+    TRY_RESULT(game_short_name, object.get_required_string_field("game_short_name"));
     return make_object<td_api::inputInlineQueryResultGame>(id, game_short_name, std::move(reply_markup));
   }
   if (type == "gif") {
-    TRY_RESULT(title, get_json_object_string_field(object, "title"));
-    TRY_RESULT(gif_url, get_json_object_string_field(object, "gif_url"));
+    TRY_RESULT(title, object.get_optional_string_field("title"));
+    TRY_RESULT(gif_url, object.get_optional_string_field("gif_url"));
     auto thumbnail_mime_type_field_name = td::Slice("thumbnail_mime_type");
-    if (!has_json_object_field(object, thumbnail_mime_type_field_name)) {
+    if (!object.has_field(thumbnail_mime_type_field_name)) {
       thumbnail_mime_type_field_name = td::Slice("thumb_mime_type");
     }
-    TRY_RESULT(thumbnail_mime_type, get_json_object_string_field(object, thumbnail_mime_type_field_name));
-    TRY_RESULT(gif_duration, get_json_object_int_field(object, "gif_duration"));
-    TRY_RESULT(gif_width, get_json_object_int_field(object, "gif_width"));
-    TRY_RESULT(gif_height, get_json_object_int_field(object, "gif_height"));
+    TRY_RESULT(thumbnail_mime_type, object.get_optional_string_field(thumbnail_mime_type_field_name));
+    TRY_RESULT(gif_duration, object.get_optional_int_field("gif_duration"));
+    TRY_RESULT(gif_width, object.get_optional_int_field("gif_width"));
+    TRY_RESULT(gif_height, object.get_optional_int_field("gif_height"));
     if (gif_url.empty()) {
-      TRY_RESULT_ASSIGN(gif_url, get_json_object_string_field(object, "gif_file_id", false));
+      TRY_RESULT_ASSIGN(gif_url, object.get_required_string_field("gif_file_id"));
     }
 
     if (input_message_content == nullptr) {
@@ -6446,13 +6449,13 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
         std::move(reply_markup), std::move(input_message_content));
   }
   if (type == "location") {
-    TRY_RESULT(latitude, get_json_object_double_field(object, "latitude", false));
-    TRY_RESULT(longitude, get_json_object_double_field(object, "longitude", false));
-    TRY_RESULT(horizontal_accuracy, get_json_object_double_field(object, "horizontal_accuracy"));
-    TRY_RESULT(live_period, get_json_object_int_field(object, "live_period"));
-    TRY_RESULT(heading, get_json_object_int_field(object, "heading"));
-    TRY_RESULT(proximity_alert_radius, get_json_object_int_field(object, "proximity_alert_radius"));
-    TRY_RESULT(title, get_json_object_string_field(object, "title", false));
+    TRY_RESULT(latitude, object.get_required_double_field("latitude"));
+    TRY_RESULT(longitude, object.get_required_double_field("longitude"));
+    TRY_RESULT(horizontal_accuracy, object.get_optional_double_field("horizontal_accuracy"));
+    TRY_RESULT(live_period, object.get_optional_int_field("live_period"));
+    TRY_RESULT(heading, object.get_optional_int_field("heading"));
+    TRY_RESULT(proximity_alert_radius, object.get_optional_int_field("proximity_alert_radius"));
+    TRY_RESULT(title, object.get_required_string_field("title"));
 
     if (input_message_content == nullptr) {
       auto location = make_object<td_api::location>(latitude, longitude, horizontal_accuracy);
@@ -6464,18 +6467,18 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
         thumbnail_width, thumbnail_height, std::move(reply_markup), std::move(input_message_content));
   }
   if (type == "mpeg4_gif") {
-    TRY_RESULT(title, get_json_object_string_field(object, "title"));
-    TRY_RESULT(mpeg4_url, get_json_object_string_field(object, "mpeg4_url"));
+    TRY_RESULT(title, object.get_optional_string_field("title"));
+    TRY_RESULT(mpeg4_url, object.get_optional_string_field("mpeg4_url"));
     auto thumbnail_mime_type_field_name = td::Slice("thumbnail_mime_type");
-    if (!has_json_object_field(object, thumbnail_mime_type_field_name)) {
+    if (!object.has_field(thumbnail_mime_type_field_name)) {
       thumbnail_mime_type_field_name = td::Slice("thumb_mime_type");
     }
-    TRY_RESULT(thumbnail_mime_type, get_json_object_string_field(object, thumbnail_mime_type_field_name));
-    TRY_RESULT(mpeg4_duration, get_json_object_int_field(object, "mpeg4_duration"));
-    TRY_RESULT(mpeg4_width, get_json_object_int_field(object, "mpeg4_width"));
-    TRY_RESULT(mpeg4_height, get_json_object_int_field(object, "mpeg4_height"));
+    TRY_RESULT(thumbnail_mime_type, object.get_optional_string_field(thumbnail_mime_type_field_name));
+    TRY_RESULT(mpeg4_duration, object.get_optional_int_field("mpeg4_duration"));
+    TRY_RESULT(mpeg4_width, object.get_optional_int_field("mpeg4_width"));
+    TRY_RESULT(mpeg4_height, object.get_optional_int_field("mpeg4_height"));
     if (mpeg4_url.empty()) {
-      TRY_RESULT_ASSIGN(mpeg4_url, get_json_object_string_field(object, "mpeg4_file_id", false));
+      TRY_RESULT_ASSIGN(mpeg4_url, object.get_required_string_field("mpeg4_file_id"));
     }
 
     if (input_message_content == nullptr) {
@@ -6487,13 +6490,13 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
         mpeg4_height, std::move(reply_markup), std::move(input_message_content));
   }
   if (type == "photo") {
-    TRY_RESULT(title, get_json_object_string_field(object, "title"));
-    TRY_RESULT(description, get_json_object_string_field(object, "description"));
-    TRY_RESULT(photo_url, get_json_object_string_field(object, "photo_url"));
-    TRY_RESULT(photo_width, get_json_object_int_field(object, "photo_width"));
-    TRY_RESULT(photo_height, get_json_object_int_field(object, "photo_height"));
+    TRY_RESULT(title, object.get_optional_string_field("title"));
+    TRY_RESULT(description, object.get_optional_string_field("description"));
+    TRY_RESULT(photo_url, object.get_optional_string_field("photo_url"));
+    TRY_RESULT(photo_width, object.get_optional_int_field("photo_width"));
+    TRY_RESULT(photo_height, object.get_optional_int_field("photo_height"));
     if (photo_url.empty()) {
-      TRY_RESULT_ASSIGN(photo_url, get_json_object_string_field(object, "photo_file_id", false));
+      TRY_RESULT_ASSIGN(photo_url, object.get_required_string_field("photo_file_id"));
     }
 
     if (input_message_content == nullptr) {
@@ -6505,7 +6508,7 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
                                                             std::move(input_message_content));
   }
   if (type == "sticker") {
-    TRY_RESULT(sticker_file_id, get_json_object_string_field(object, "sticker_file_id", false));
+    TRY_RESULT(sticker_file_id, object.get_required_string_field("sticker_file_id"));
 
     if (input_message_content == nullptr) {
       input_message_content = make_object<td_api::inputMessageSticker>(nullptr, nullptr, 0, 0, td::string());
@@ -6514,15 +6517,15 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
                                                               std::move(input_message_content));
   }
   if (type == "venue") {
-    TRY_RESULT(latitude, get_json_object_double_field(object, "latitude", false));
-    TRY_RESULT(longitude, get_json_object_double_field(object, "longitude", false));
-    TRY_RESULT(horizontal_accuracy, get_json_object_double_field(object, "horizontal_accuracy"));
-    TRY_RESULT(title, get_json_object_string_field(object, "title", false));
-    TRY_RESULT(address, get_json_object_string_field(object, "address", false));
-    TRY_RESULT(foursquare_id, get_json_object_string_field(object, "foursquare_id"));
-    TRY_RESULT(foursquare_type, get_json_object_string_field(object, "foursquare_type"));
-    TRY_RESULT(google_place_id, get_json_object_string_field(object, "google_place_id"));
-    TRY_RESULT(google_place_type, get_json_object_string_field(object, "google_place_type"));
+    TRY_RESULT(latitude, object.get_required_double_field("latitude"));
+    TRY_RESULT(longitude, object.get_required_double_field("longitude"));
+    TRY_RESULT(horizontal_accuracy, object.get_optional_double_field("horizontal_accuracy"));
+    TRY_RESULT(title, object.get_required_string_field("title"));
+    TRY_RESULT(address, object.get_required_string_field("address"));
+    TRY_RESULT(foursquare_id, object.get_optional_string_field("foursquare_id"));
+    TRY_RESULT(foursquare_type, object.get_optional_string_field("foursquare_type"));
+    TRY_RESULT(google_place_id, object.get_optional_string_field("google_place_id"));
+    TRY_RESULT(google_place_type, object.get_optional_string_field("google_place_type"));
 
     td::string provider;
     td::string venue_id;
@@ -6550,15 +6553,16 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
         thumbnail_url, thumbnail_width, thumbnail_height, std::move(reply_markup), std::move(input_message_content));
   }
   if (type == "video") {
-    TRY_RESULT(title, get_json_object_string_field(object, "title", false));
-    TRY_RESULT(description, get_json_object_string_field(object, "description"));
-    TRY_RESULT(video_url, get_json_object_string_field(object, "video_url"));
-    TRY_RESULT(mime_type, get_json_object_string_field(object, "mime_type", video_url.empty()));
-    TRY_RESULT(video_width, get_json_object_int_field(object, "video_width"));
-    TRY_RESULT(video_height, get_json_object_int_field(object, "video_height"));
-    TRY_RESULT(video_duration, get_json_object_int_field(object, "video_duration"));
+    TRY_RESULT(title, object.get_required_string_field("title"));
+    TRY_RESULT(description, object.get_optional_string_field("description"));
+    TRY_RESULT(video_url, object.get_optional_string_field("video_url"));
+    TRY_RESULT(mime_type, video_url.empty() ? object.get_optional_string_field("mime_type")
+                                            : object.get_required_string_field("mime_type"));
+    TRY_RESULT(video_width, object.get_optional_int_field("video_width"));
+    TRY_RESULT(video_height, object.get_optional_int_field("video_height"));
+    TRY_RESULT(video_duration, object.get_optional_int_field("video_duration"));
     if (video_url.empty()) {
-      TRY_RESULT_ASSIGN(video_url, get_json_object_string_field(object, "video_file_id", false));
+      TRY_RESULT_ASSIGN(video_url, object.get_required_string_field("video_file_id"));
     }
 
     if (input_message_content == nullptr) {
@@ -6571,11 +6575,11 @@ td::Result<td_api::object_ptr<td_api::InputInlineQueryResult>> Client::get_inlin
                                                             std::move(reply_markup), std::move(input_message_content));
   }
   if (type == "voice") {
-    TRY_RESULT(title, get_json_object_string_field(object, "title", false));
-    TRY_RESULT(voice_note_url, get_json_object_string_field(object, "voice_url"));
-    TRY_RESULT(voice_note_duration, get_json_object_int_field(object, "voice_duration"));
+    TRY_RESULT(title, object.get_required_string_field("title"));
+    TRY_RESULT(voice_note_url, object.get_optional_string_field("voice_url"));
+    TRY_RESULT(voice_note_duration, object.get_optional_int_field("voice_duration"));
     if (voice_note_url.empty()) {
-      TRY_RESULT_ASSIGN(voice_note_url, get_json_object_string_field(object, "voice_file_id", false));
+      TRY_RESULT_ASSIGN(voice_note_url, object.get_required_string_field("voice_file_id"));
     }
 
     if (input_message_content == nullptr) {
@@ -6596,7 +6600,7 @@ td::Result<Client::BotCommandScope> Client::get_bot_command_scope(td::JsonValue 
 
   auto &object = value.get_object();
 
-  TRY_RESULT(type, get_json_object_string_field(object, "type", false));
+  TRY_RESULT(type, object.get_required_string_field("type"));
   if (type == "default") {
     return BotCommandScope(make_object<td_api::botCommandScopeDefault>());
   }
@@ -6613,7 +6617,7 @@ td::Result<Client::BotCommandScope> Client::get_bot_command_scope(td::JsonValue 
     return td::Status::Error(400, "Unsupported type specified");
   }
 
-  TRY_RESULT(chat_id, get_json_object_string_field(object, "chat_id", false));
+  TRY_RESULT(chat_id, object.get_required_string_field("chat_id"));
   if (chat_id.empty()) {
     return td::Status::Error(400, "Empty chat_id specified");
   }
@@ -6624,7 +6628,7 @@ td::Result<Client::BotCommandScope> Client::get_bot_command_scope(td::JsonValue 
     return BotCommandScope(make_object<td_api::botCommandScopeChatAdministrators>(0), std::move(chat_id));
   }
 
-  TRY_RESULT(user_id, get_json_object_long_field(object, "user_id", false));
+  TRY_RESULT(user_id, object.get_required_long_field("user_id"));
   if (user_id <= 0) {
     return td::Status::Error(400, "Invalid user_id specified");
   }
@@ -6659,8 +6663,8 @@ td::Result<td_api::object_ptr<td_api::botCommand>> Client::get_bot_command(td::J
 
   auto &object = value.get_object();
 
-  TRY_RESULT(command, get_json_object_string_field(object, "command", false));
-  TRY_RESULT(description, get_json_object_string_field(object, "description", false));
+  TRY_RESULT(command, object.get_required_string_field("command"));
+  TRY_RESULT(description, object.get_required_string_field("description"));
 
   return make_object<td_api::botCommand>(command, description);
 }
@@ -6700,7 +6704,7 @@ td::Result<td_api::object_ptr<td_api::botMenuButton>> Client::get_bot_menu_butto
 
   auto &object = value.get_object();
 
-  TRY_RESULT(type, get_json_object_string_field(object, "type", false));
+  TRY_RESULT(type, object.get_required_string_field("type"));
   if (type == "default") {
     return make_object<td_api::botMenuButton>("", "default");
   }
@@ -6708,10 +6712,10 @@ td::Result<td_api::object_ptr<td_api::botMenuButton>> Client::get_bot_menu_butto
     return nullptr;
   }
   if (type == "web_app") {
-    TRY_RESULT(text, get_json_object_string_field(object, "text", false));
-    TRY_RESULT(web_app, get_json_object_field(object, "web_app", td::JsonValue::Type::Object, false));
+    TRY_RESULT(text, object.get_required_string_field("text"));
+    TRY_RESULT(web_app, object.extract_required_field("web_app", td::JsonValue::Type::Object));
     auto &web_app_object = web_app.get_object();
-    TRY_RESULT(url, get_json_object_string_field(web_app_object, "url", false));
+    TRY_RESULT(url, web_app_object.get_required_string_field("url"));
     return make_object<td_api::botMenuButton>(text, url);
   }
 
@@ -6745,18 +6749,18 @@ td::Result<td_api::object_ptr<td_api::chatAdministratorRights>> Client::get_chat
   }
 
   auto &object = value.get_object();
-  TRY_RESULT(can_manage_chat, get_json_object_bool_field(object, "can_manage_chat"));
-  TRY_RESULT(can_change_info, get_json_object_bool_field(object, "can_change_info"));
-  TRY_RESULT(can_post_messages, get_json_object_bool_field(object, "can_post_messages"));
-  TRY_RESULT(can_edit_messages, get_json_object_bool_field(object, "can_edit_messages"));
-  TRY_RESULT(can_delete_messages, get_json_object_bool_field(object, "can_delete_messages"));
-  TRY_RESULT(can_invite_users, get_json_object_bool_field(object, "can_invite_users"));
-  TRY_RESULT(can_restrict_members, get_json_object_bool_field(object, "can_restrict_members"));
-  TRY_RESULT(can_pin_messages, get_json_object_bool_field(object, "can_pin_messages"));
-  TRY_RESULT(can_manage_topics, get_json_object_bool_field(object, "can_manage_topics"));
-  TRY_RESULT(can_promote_members, get_json_object_bool_field(object, "can_promote_members"));
-  TRY_RESULT(can_manage_video_chats, get_json_object_bool_field(object, "can_manage_video_chats"));
-  TRY_RESULT(is_anonymous, get_json_object_bool_field(object, "is_anonymous"));
+  TRY_RESULT(can_manage_chat, object.get_optional_bool_field("can_manage_chat"));
+  TRY_RESULT(can_change_info, object.get_optional_bool_field("can_change_info"));
+  TRY_RESULT(can_post_messages, object.get_optional_bool_field("can_post_messages"));
+  TRY_RESULT(can_edit_messages, object.get_optional_bool_field("can_edit_messages"));
+  TRY_RESULT(can_delete_messages, object.get_optional_bool_field("can_delete_messages"));
+  TRY_RESULT(can_invite_users, object.get_optional_bool_field("can_invite_users"));
+  TRY_RESULT(can_restrict_members, object.get_optional_bool_field("can_restrict_members"));
+  TRY_RESULT(can_pin_messages, object.get_optional_bool_field("can_pin_messages"));
+  TRY_RESULT(can_manage_topics, object.get_optional_bool_field("can_manage_topics"));
+  TRY_RESULT(can_promote_members, object.get_optional_bool_field("can_promote_members"));
+  TRY_RESULT(can_manage_video_chats, object.get_optional_bool_field("can_manage_video_chats"));
+  TRY_RESULT(is_anonymous, object.get_optional_bool_field("is_anonymous"));
   return make_object<td_api::chatAdministratorRights>(can_manage_chat, can_change_info, can_post_messages,
                                                       can_edit_messages, can_delete_messages, can_invite_users,
                                                       can_restrict_members, can_pin_messages, can_manage_topics,
@@ -6794,7 +6798,7 @@ td::Result<td_api::object_ptr<td_api::maskPosition>> Client::get_mask_position(t
 
   auto &object = value.get_object();
 
-  TRY_RESULT(point_str, get_json_object_string_field(object, "point", false));
+  TRY_RESULT(point_str, object.get_required_string_field("point"));
   point_str = td::trim(td::to_lower(point_str));
   int32 point;
   for (point = 0; point < MASK_POINTS_SIZE; point++) {
@@ -6806,9 +6810,9 @@ td::Result<td_api::object_ptr<td_api::maskPosition>> Client::get_mask_position(t
     return td::Status::Error(400, "Wrong point specified in MaskPosition");
   }
 
-  TRY_RESULT(x_shift, get_json_object_double_field(object, "x_shift", false));
-  TRY_RESULT(y_shift, get_json_object_double_field(object, "y_shift", false));
-  TRY_RESULT(scale, get_json_object_double_field(object, "scale", false));
+  TRY_RESULT(x_shift, object.get_required_double_field("x_shift"));
+  TRY_RESULT(y_shift, object.get_required_double_field("y_shift"));
+  TRY_RESULT(scale, object.get_required_double_field("scale"));
 
   return make_object<td_api::maskPosition>(mask_index_to_point(point), x_shift, y_shift, scale);
 }
@@ -6928,17 +6932,17 @@ td::Result<td_api::object_ptr<td_api::inputSticker>> Client::get_input_sticker(c
 
   auto &object = value.get_object();
 
-  TRY_RESULT(sticker, get_json_object_string_field(object, "sticker"));
+  TRY_RESULT(sticker, object.get_optional_string_field("sticker"));
   auto input_file = get_input_file(query, td::Slice(), sticker, false);
   if (input_file == nullptr) {
     return td::Status::Error(400, "sticker not found");
   }
-  TRY_RESULT(emoji_list, get_json_object_field(object, "emoji_list", td::JsonValue::Type::Array, false));
+  TRY_RESULT(emoji_list, object.extract_required_field("emoji_list", td::JsonValue::Type::Array));
   TRY_RESULT(emojis, get_sticker_emojis(std::move(emoji_list)));
-  TRY_RESULT(mask_position, get_mask_position(get_json_object_field_force(object, "mask_position")));
+  TRY_RESULT(mask_position, get_mask_position(object.extract_field("mask_position")));
   td::vector<td::string> input_keywords;
-  if (has_json_object_field(object, "keywords")) {
-    TRY_RESULT(keywords, get_json_object_field(object, "keywords", td::JsonValue::Type::Array, false));
+  if (object.has_field("keywords")) {
+    TRY_RESULT(keywords, object.extract_required_field("keywords", td::JsonValue::Type::Array));
     for (auto &keyword : keywords.get_array()) {
       if (keyword.type() != td::JsonValue::Type::String) {
         return td::Status::Error(400, "keyword must be a string");
@@ -7076,24 +7080,24 @@ td::Result<td::string> Client::get_passport_element_hash(td::Slice encoded_hash)
 
 td::Result<td_api::object_ptr<td_api::InputPassportElementErrorSource>> Client::get_passport_element_error_source(
     td::JsonObject &object) {
-  TRY_RESULT(source, get_json_object_string_field(object, "source"));
+  TRY_RESULT(source, object.get_optional_string_field("source"));
 
   if (source.empty() || source == "unspecified") {
-    TRY_RESULT(element_hash, get_json_object_string_field(object, "element_hash", false));
+    TRY_RESULT(element_hash, object.get_required_string_field("element_hash"));
     TRY_RESULT(hash, get_passport_element_hash(element_hash));
 
     return make_object<td_api::inputPassportElementErrorSourceUnspecified>(hash);
   }
   if (source == "data") {
-    TRY_RESULT(data_hash, get_json_object_string_field(object, "data_hash", false));
+    TRY_RESULT(data_hash, object.get_required_string_field("data_hash"));
     TRY_RESULT(hash, get_passport_element_hash(data_hash));
 
-    TRY_RESULT(field_name, get_json_object_string_field(object, "field_name", false));
+    TRY_RESULT(field_name, object.get_required_string_field("field_name"));
     return make_object<td_api::inputPassportElementErrorSourceDataField>(field_name, hash);
   }
   if (source == "file" || source == "selfie" || source == "translation_file" || source == "front_side" ||
       source == "reverse_side") {
-    TRY_RESULT(file_hash, get_json_object_string_field(object, "file_hash", false));
+    TRY_RESULT(file_hash, object.get_required_string_field("file_hash"));
     TRY_RESULT(hash, get_passport_element_hash(file_hash));
 
     if (source == "front_side") {
@@ -7115,7 +7119,7 @@ td::Result<td_api::object_ptr<td_api::InputPassportElementErrorSource>> Client::
   }
   if (source == "files" || source == "translation_files") {
     td::vector<td::string> input_hashes;
-    TRY_RESULT(file_hashes, get_json_object_field(object, "file_hashes", td::JsonValue::Type::Array, false));
+    TRY_RESULT(file_hashes, object.extract_required_field("file_hashes", td::JsonValue::Type::Array));
     for (auto &input_hash : file_hashes.get_array()) {
       if (input_hash.type() != td::JsonValue::Type::String) {
         return td::Status::Error(400, "hash must be a string");
@@ -7142,12 +7146,12 @@ td::Result<td_api::object_ptr<td_api::inputPassportElementError>> Client::get_pa
 
   auto &object = value.get_object();
 
-  TRY_RESULT(input_type, get_json_object_string_field(object, "type", false));
+  TRY_RESULT(input_type, object.get_required_string_field("type"));
   auto type = get_passport_element_type(input_type);
   if (type == nullptr) {
     return td::Status::Error(400, "wrong Telegram Passport element type specified");
   }
-  TRY_RESULT(message, get_json_object_string_field(object, "message", false));
+  TRY_RESULT(message, object.get_required_string_field("message"));
   TRY_RESULT(source, get_passport_element_error_source(object));
 
   return make_object<td_api::inputPassportElementError>(std::move(type), message, std::move(source));
@@ -7199,7 +7203,7 @@ td::Result<td_api::object_ptr<td_api::formattedText>> Client::get_caption(const 
 }
 
 td::Result<td_api::object_ptr<td_api::TextEntityType>> Client::get_text_entity_type(td::JsonObject &object) {
-  TRY_RESULT(type, get_json_object_string_field(object, "type", false));
+  TRY_RESULT(type, object.get_required_string_field("type"));
   if (type.empty()) {
     return td::Status::Error("Type is not specified");
   }
@@ -7223,24 +7227,25 @@ td::Result<td_api::object_ptr<td_api::TextEntityType>> Client::get_text_entity_t
     return make_object<td_api::textEntityTypeCode>();
   }
   if (type == "pre") {
-    TRY_RESULT(language, get_json_object_string_field(object, "language"));
+    TRY_RESULT(language, object.get_optional_string_field("language"));
     if (language.empty()) {
       return make_object<td_api::textEntityTypePre>();
     }
     return make_object<td_api::textEntityTypePreCode>(language);
   }
   if (type == "text_link") {
-    TRY_RESULT(url, get_json_object_string_field(object, "url", false));
+    TRY_RESULT(url, object.get_required_string_field("url"));
     return make_object<td_api::textEntityTypeTextUrl>(url);
   }
   if (type == "text_mention") {
-    TRY_RESULT(user, get_json_object_field(object, "user", td::JsonValue::Type::Object, false));
+    TRY_RESULT(user, object.extract_required_field("user", td::JsonValue::Type::Object));
     CHECK(user.type() == td::JsonValue::Type::Object);
-    TRY_RESULT(user_id, get_json_object_long_field(user.get_object(), "id", false));
+    const auto &user_object = user.get_object();
+    TRY_RESULT(user_id, user_object.get_required_long_field("id"));
     return make_object<td_api::textEntityTypeMentionName>(user_id);
   }
   if (type == "custom_emoji") {
-    TRY_RESULT(custom_emoji_id, get_json_object_long_field(object, "custom_emoji_id", false));
+    TRY_RESULT(custom_emoji_id, object.get_required_long_field("custom_emoji_id"));
     return make_object<td_api::textEntityTypeCustomEmoji>(custom_emoji_id);
   }
   if (type == "mention" || type == "hashtag" || type == "cashtag" || type == "bot_command" || type == "url" ||
@@ -7257,8 +7262,8 @@ td::Result<td_api::object_ptr<td_api::textEntity>> Client::get_text_entity(td::J
   }
 
   auto &object = value.get_object();
-  TRY_RESULT(offset, get_json_object_int_field(object, "offset", false));
-  TRY_RESULT(length, get_json_object_int_field(object, "length", false));
+  TRY_RESULT(offset, object.get_required_int_field("offset"));
+  TRY_RESULT(length, object.get_required_int_field("length"));
   TRY_RESULT(type, get_text_entity_type(object));
 
   if (type == nullptr) {
@@ -7374,30 +7379,29 @@ td::Result<td_api::object_ptr<td_api::chatPermissions>> Client::get_chat_permiss
     auto &object = value.get_object();
 
     auto status = [&] {
-      TRY_RESULT_ASSIGN(can_send_messages, get_json_object_bool_field(object, "can_send_messages"));
-      TRY_RESULT_ASSIGN(can_send_polls, get_json_object_bool_field(object, "can_send_polls"));
-      TRY_RESULT_ASSIGN(can_send_other_messages, get_json_object_bool_field(object, "can_send_other_messages"));
-      TRY_RESULT_ASSIGN(can_add_web_page_previews, get_json_object_bool_field(object, "can_add_web_page_previews"));
-      TRY_RESULT_ASSIGN(can_change_info, get_json_object_bool_field(object, "can_change_info"));
-      TRY_RESULT_ASSIGN(can_invite_users, get_json_object_bool_field(object, "can_invite_users"));
-      TRY_RESULT_ASSIGN(can_pin_messages, get_json_object_bool_field(object, "can_pin_messages"));
-      if (has_json_object_field(object, "can_manage_topics")) {
-        TRY_RESULT_ASSIGN(can_manage_topics, get_json_object_bool_field(object, "can_manage_topics"));
+      TRY_RESULT_ASSIGN(can_send_messages, object.get_optional_bool_field("can_send_messages"));
+      TRY_RESULT_ASSIGN(can_send_polls, object.get_optional_bool_field("can_send_polls"));
+      TRY_RESULT_ASSIGN(can_send_other_messages, object.get_optional_bool_field("can_send_other_messages"));
+      TRY_RESULT_ASSIGN(can_add_web_page_previews, object.get_optional_bool_field("can_add_web_page_previews"));
+      TRY_RESULT_ASSIGN(can_change_info, object.get_optional_bool_field("can_change_info"));
+      TRY_RESULT_ASSIGN(can_invite_users, object.get_optional_bool_field("can_invite_users"));
+      TRY_RESULT_ASSIGN(can_pin_messages, object.get_optional_bool_field("can_pin_messages"));
+      if (object.has_field("can_manage_topics")) {
+        TRY_RESULT_ASSIGN(can_manage_topics, object.get_optional_bool_field("can_manage_topics"));
       } else {
         can_manage_topics = can_pin_messages;
       }
-      if (has_json_object_field(object, "can_send_audios") || has_json_object_field(object, "can_send_documents") ||
-          has_json_object_field(object, "can_send_photos") || has_json_object_field(object, "can_send_videos") ||
-          has_json_object_field(object, "can_send_video_notes") ||
-          has_json_object_field(object, "can_send_voice_notes")) {
-        TRY_RESULT_ASSIGN(can_send_audios, get_json_object_bool_field(object, "can_send_audios"));
-        TRY_RESULT_ASSIGN(can_send_documents, get_json_object_bool_field(object, "can_send_documents"));
-        TRY_RESULT_ASSIGN(can_send_photos, get_json_object_bool_field(object, "can_send_photos"));
-        TRY_RESULT_ASSIGN(can_send_videos, get_json_object_bool_field(object, "can_send_videos"));
-        TRY_RESULT_ASSIGN(can_send_video_notes, get_json_object_bool_field(object, "can_send_video_notes"));
-        TRY_RESULT_ASSIGN(can_send_voice_notes, get_json_object_bool_field(object, "can_send_voice_notes"));
+      if (object.has_field("can_send_audios") || object.has_field("can_send_documents") ||
+          object.has_field("can_send_photos") || object.has_field("can_send_videos") ||
+          object.has_field("can_send_video_notes") || object.has_field("can_send_voice_notes")) {
+        TRY_RESULT_ASSIGN(can_send_audios, object.get_optional_bool_field("can_send_audios"));
+        TRY_RESULT_ASSIGN(can_send_documents, object.get_optional_bool_field("can_send_documents"));
+        TRY_RESULT_ASSIGN(can_send_photos, object.get_optional_bool_field("can_send_photos"));
+        TRY_RESULT_ASSIGN(can_send_videos, object.get_optional_bool_field("can_send_videos"));
+        TRY_RESULT_ASSIGN(can_send_video_notes, object.get_optional_bool_field("can_send_video_notes"));
+        TRY_RESULT_ASSIGN(can_send_voice_notes, object.get_optional_bool_field("can_send_voice_notes"));
       } else {
-        TRY_RESULT(can_send_media_messages, get_json_object_bool_field(object, "can_send_media_messages"));
+        TRY_RESULT(can_send_media_messages, object.get_optional_bool_field("can_send_media_messages"));
         can_send_audios = can_send_media_messages;
         can_send_documents = can_send_media_messages;
         can_send_photos = can_send_media_messages;
@@ -7476,23 +7480,23 @@ td::Result<td_api::object_ptr<td_api::InputMessageContent>> Client::get_input_me
 
   auto &object = input_media.get_object();
 
-  TRY_RESULT(input_caption, get_json_object_string_field(object, "caption"));
-  TRY_RESULT(parse_mode, get_json_object_string_field(object, "parse_mode"));
-  auto entities = get_json_object_field_force(object, "caption_entities");
+  TRY_RESULT(input_caption, object.get_optional_string_field("caption"));
+  TRY_RESULT(parse_mode, object.get_optional_string_field("parse_mode"));
+  auto entities = object.extract_field("caption_entities");
   TRY_RESULT(caption, get_formatted_text(std::move(input_caption), std::move(parse_mode), std::move(entities)));
-  // TRY_RESULT(self_destruct_time, get_json_object_int_field(object, "self_destruct_time"));
+  // TRY_RESULT(self_destruct_time, object.get_optional_int_field("self_destruct_time"));
   int32 self_destruct_time = 0;
-  TRY_RESULT(has_spoiler, get_json_object_bool_field(object, "has_spoiler"));
-  TRY_RESULT(media, get_json_object_string_field(object, "media"));
+  TRY_RESULT(has_spoiler, object.get_optional_bool_field("has_spoiler"));
+  TRY_RESULT(media, object.get_optional_string_field("media"));
 
   auto input_file = get_input_file(query, td::Slice(), media, false);
   if (input_file == nullptr) {
     return td::Status::Error("media not found");
   }
 
-  TRY_RESULT(thumbnail, get_json_object_string_field(object, "thumbnail"));
+  TRY_RESULT(thumbnail, object.get_optional_string_field("thumbnail"));
   if (thumbnail.empty()) {
-    TRY_RESULT_ASSIGN(thumbnail, get_json_object_string_field(object, "thumb"));
+    TRY_RESULT_ASSIGN(thumbnail, object.get_optional_string_field("thumb"));
   }
   auto thumbnail_input_file = get_input_file(query, td::Slice(), thumbnail, true);
   if (thumbnail_input_file == nullptr) {
@@ -7506,16 +7510,16 @@ td::Result<td_api::object_ptr<td_api::InputMessageContent>> Client::get_input_me
     input_thumbnail = make_object<td_api::inputThumbnail>(std::move(thumbnail_input_file), 0, 0);
   }
 
-  TRY_RESULT(type, get_json_object_string_field(object, "type", false));
+  TRY_RESULT(type, object.get_required_string_field("type"));
   if (type == "photo") {
     return make_object<td_api::inputMessagePhoto>(std::move(input_file), nullptr, td::vector<int32>(), 0, 0,
                                                   std::move(caption), self_destruct_time, has_spoiler);
   }
   if (type == "video") {
-    TRY_RESULT(width, get_json_object_int_field(object, "width"));
-    TRY_RESULT(height, get_json_object_int_field(object, "height"));
-    TRY_RESULT(duration, get_json_object_int_field(object, "duration"));
-    TRY_RESULT(supports_streaming, get_json_object_bool_field(object, "supports_streaming"));
+    TRY_RESULT(width, object.get_optional_int_field("width"));
+    TRY_RESULT(height, object.get_optional_int_field("height"));
+    TRY_RESULT(duration, object.get_optional_int_field("duration"));
+    TRY_RESULT(supports_streaming, object.get_optional_bool_field("supports_streaming"));
     width = td::clamp(width, 0, MAX_LENGTH);
     height = td::clamp(height, 0, MAX_LENGTH);
     duration = td::clamp(duration, 0, MAX_DURATION);
@@ -7528,9 +7532,9 @@ td::Result<td_api::object_ptr<td_api::InputMessageContent>> Client::get_input_me
     return td::Status::Error(PSLICE() << "type \"" << type << "\" can't be used in sendMediaGroup");
   }
   if (type == "animation") {
-    TRY_RESULT(width, get_json_object_int_field(object, "width"));
-    TRY_RESULT(height, get_json_object_int_field(object, "height"));
-    TRY_RESULT(duration, get_json_object_int_field(object, "duration"));
+    TRY_RESULT(width, object.get_optional_int_field("width"));
+    TRY_RESULT(height, object.get_optional_int_field("height"));
+    TRY_RESULT(duration, object.get_optional_int_field("duration"));
     width = td::clamp(width, 0, MAX_LENGTH);
     height = td::clamp(height, 0, MAX_LENGTH);
     duration = td::clamp(duration, 0, MAX_DURATION);
@@ -7539,15 +7543,15 @@ td::Result<td_api::object_ptr<td_api::InputMessageContent>> Client::get_input_me
                                                       has_spoiler);
   }
   if (type == "audio") {
-    TRY_RESULT(duration, get_json_object_int_field(object, "duration"));
-    TRY_RESULT(title, get_json_object_string_field(object, "title"));
-    TRY_RESULT(performer, get_json_object_string_field(object, "performer"));
+    TRY_RESULT(duration, object.get_optional_int_field("duration"));
+    TRY_RESULT(title, object.get_optional_string_field("title"));
+    TRY_RESULT(performer, object.get_optional_string_field("performer"));
     duration = td::clamp(duration, 0, MAX_DURATION);
     return make_object<td_api::inputMessageAudio>(std::move(input_file), std::move(input_thumbnail), duration, title,
                                                   performer, std::move(caption));
   }
   if (type == "document") {
-    TRY_RESULT(disable_content_type_detection, get_json_object_bool_field(object, "disable_content_type_detection"));
+    TRY_RESULT(disable_content_type_detection, object.get_optional_bool_field("disable_content_type_detection"));
     return make_object<td_api::inputMessageDocument>(std::move(input_file), std::move(input_thumbnail),
                                                      disable_content_type_detection || for_album, std::move(caption));
   }

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -276,6 +276,7 @@ bool Client::init_methods() {
   methods_.emplace("reopengeneralforumtopic", &Client::process_reopen_general_forum_topic_query);
   methods_.emplace("hidegeneralforumtopic", &Client::process_hide_general_forum_topic_query);
   methods_.emplace("unhidegeneralforumtopic", &Client::process_unhide_general_forum_topic_query);
+  methods_.emplace("unpinallgeneralforumtopicmessages", &Client::process_unpin_all_general_forum_topic_messages_query);
   methods_.emplace("getchatmember", &Client::process_get_chat_member_query);
   methods_.emplace("getchatadministrators", &Client::process_get_chat_administrators_query);
   methods_.emplace("getchatmembercount", &Client::process_get_chat_member_count_query);
@@ -9097,6 +9098,16 @@ td::Status Client::process_unhide_general_forum_topic_query(PromisedQueryPtr &qu
 
   check_chat(chat_id, AccessRights::Write, std::move(query), [this](int64 chat_id, PromisedQueryPtr query) {
     send_request(make_object<td_api::toggleGeneralForumTopicIsHidden>(chat_id, false),
+                 td::make_unique<TdOnOkQueryCallback>(std::move(query)));
+  });
+  return td::Status::OK();
+}
+
+td::Status Client::process_unpin_all_general_forum_topic_messages_query(PromisedQueryPtr &query) {
+  auto chat_id = query->arg("chat_id");
+
+  check_chat(chat_id, AccessRights::Write, std::move(query), [this](int64 chat_id, PromisedQueryPtr query) {
+    send_request(make_object<td_api::unpinAllMessageThreadMessages>(chat_id, GENERAL_MESSAGE_THREAD_ID),
                  td::make_unique<TdOnOkQueryCallback>(std::move(query)));
   });
   return td::Status::OK();

--- a/telegram-bot-api/Client.cpp
+++ b/telegram-bot-api/Client.cpp
@@ -5572,7 +5572,7 @@ void Client::on_update_file(object_ptr<td_api::file> file) {
   if (!is_file_being_downloaded(file_id)) {
     return;
   }
-  if ((!parameters_->local_mode_ || !parameters_->no_file_limit_) && file->local_->downloaded_size_ > MAX_DOWNLOAD_FILE_SIZE) {
+  if ((!parameters_->local_mode_ && !parameters_->no_file_limit_) && file->local_->downloaded_size_ > MAX_DOWNLOAD_FILE_SIZE) {
     if (file->local_->is_downloading_active_) {
       send_request(make_object<td_api::cancelDownloadFile>(file_id, false),
                    td::make_unique<TdOnCancelDownloadFileCallback>());
@@ -11099,7 +11099,7 @@ void Client::process_register_user_query(PromisedQueryPtr &query) {
 //end custom auth methods impl
 
 void Client::do_get_file(object_ptr<td_api::file> file, PromisedQueryPtr query) {
-  if ((!parameters_->local_mode_ || !parameters_->no_file_limit_) &&
+  if ((!parameters_->local_mode_ && !parameters_->no_file_limit_) &&
       td::max(file->expected_size_, file->local_->downloaded_size_) > MAX_DOWNLOAD_FILE_SIZE) {  // speculative check
     return fail_query(400, "Bad Request: file is too big", std::move(query));
   }

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -505,7 +505,9 @@ class Client final : public WebhookActor::Callback {
   int64 extract_yet_unsent_message_query_id(int64 chat_id, int64 message_id);
 
   void on_message_send_succeeded(object_ptr<td_api::message> &&message, int64 old_message_id);
-  void on_message_send_failed(int64 chat_id, int64 old_message_id, int64 new_message_id, td::Status result);
+
+  void on_message_send_failed(int64 chat_id, int64 old_message_id, int64 new_message_id,
+                              object_ptr<td_api::error> &&error);
 
   static bool init_methods();
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -832,7 +832,11 @@ class Client final : public WebhookActor::Callback {
     mutable bool is_content_changed = false;
   };
 
-  static int64 &get_reply_to_message_id(object_ptr<td_api::message> &message);
+  static int64 get_reply_to_message_id(const object_ptr<td_api::message> &message);
+
+  static void drop_reply_to_message_id(object_ptr<td_api::message> &message);
+
+  static void drop_reply_to_message_in_another_chat(object_ptr<td_api::message> &message);
 
   void set_message_reply_to_message_id(MessageInfo *message_info, int64 reply_to_message_id);
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -709,6 +709,7 @@ class Client final : public WebhookActor::Callback {
     td::string editable_username;
     td::string language_code;
     int64 emoji_status_custom_emoji_id;
+    int32 emoji_status_expiration_date;
 
     object_ptr<td_api::chatPhoto> photo;
     td::string bio;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -746,7 +746,7 @@ class Client final : public WebhookActor::Callback {
   };
   static void add_group(GroupInfo *group_info, object_ptr<td_api::basicGroup> &&group);
   void set_group_photo(int64 group_id, object_ptr<td_api::chatPhoto> &&photo);
-  void set_group_description(int64 group_id, td::string &&descripton);
+  void set_group_description(int64 group_id, td::string &&description);
   void set_group_invite_link(int64 group_id, td::string &&invite_link);
   GroupInfo *add_group_info(int64 group_id);
   const GroupInfo *get_group_info(int64 group_id) const;
@@ -774,7 +774,7 @@ class Client final : public WebhookActor::Callback {
   };
   static void add_supergroup(SupergroupInfo *supergroup_info, object_ptr<td_api::supergroup> &&supergroup);
   void set_supergroup_photo(int64 supergroup_id, object_ptr<td_api::chatPhoto> &&photo);
-  void set_supergroup_description(int64 supergroup_id, td::string &&descripton);
+  void set_supergroup_description(int64 supergroup_id, td::string &&description);
   void set_supergroup_invite_link(int64 supergroup_id, td::string &&invite_link);
   void set_supergroup_sticker_set_id(int64 supergroup_id, int64 sticker_set_id);
   void set_supergroup_can_set_sticker_set(int64 supergroup_id, bool can_set_sticker_set);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -500,7 +500,7 @@ class Client final : public WebhookActor::Callback {
 
   void decrease_yet_unsent_message_count(int64 chat_id, int32 count);
 
-  int64 extract_yet_unsent_message_query_id(int64 chat_id, int64 message_id, bool *is_reply_to_message_deleted);
+  int64 extract_yet_unsent_message_query_id(int64 chat_id, int64 message_id);
 
   void on_message_send_succeeded(object_ptr<td_api::message> &&message, int64 old_message_id);
   void on_message_send_failed(int64 chat_id, int64 old_message_id, int64 new_message_id, td::Status result);
@@ -828,7 +828,6 @@ class Client final : public WebhookActor::Callback {
     bool can_be_saved = false;
     bool is_automatic_forward = false;
     bool is_topic_message = false;
-    mutable bool is_reply_to_message_deleted = false;
     mutable bool is_content_changed = false;
   };
 
@@ -1040,15 +1039,11 @@ class Client final : public WebhookActor::Callback {
 
   td::FlatHashMap<FullMessageId, td::FlatHashSet<int64>, FullMessageIdHash>
       reply_message_ids_;  // message -> replies to it
-  td::FlatHashMap<FullMessageId, td::FlatHashSet<int64>, FullMessageIdHash>
-      yet_unsent_reply_message_ids_;  // message -> replies to it
 
   td::FlatHashMap<int32, td::vector<PromisedQueryPtr>> file_download_listeners_;
   td::FlatHashSet<int32> download_started_file_ids_;
 
   struct YetUnsentMessage {
-    int64 reply_to_message_id = 0;
-    bool is_reply_to_message_deleted = false;
     int64 send_message_query_id = 0;
   };
   td::FlatHashMap<FullMessageId, YetUnsentMessage, FullMessageIdHash> yet_unsent_messages_;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -837,9 +837,11 @@ class Client final : public WebhookActor::Callback {
     mutable bool is_content_changed = false;
   };
 
-  static int64 get_same_chat_reply_to_message_id(const td_api::messageReplyToMessage *reply_to);
+  static int64 get_same_chat_reply_to_message_id(const td_api::messageReplyToMessage *reply_to,
+                                                 int64 message_thread_id);
 
-  static int64 get_same_chat_reply_to_message_id(const object_ptr<td_api::MessageReplyTo> &reply_to);
+  static int64 get_same_chat_reply_to_message_id(const object_ptr<td_api::MessageReplyTo> &reply_to,
+                                                 int64 message_thread_id);
 
   static int64 get_same_chat_reply_to_message_id(const object_ptr<td_api::message> &message);
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -1153,6 +1153,8 @@ class Client final : public WebhookActor::Callback {
   double previous_get_updates_finish_time_ = 0;
   double next_get_updates_conflict_time_ = 0;
 
+  int32 log_in_date_ = 0;
+
   int32 flood_limited_query_count_ = 0;
   double next_flood_limit_warning_time_ = 0;
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -590,6 +590,7 @@ class Client final : public WebhookActor::Callback {
   td::Status process_reopen_general_forum_topic_query(PromisedQueryPtr &query);
   td::Status process_hide_general_forum_topic_query(PromisedQueryPtr &query);
   td::Status process_unhide_general_forum_topic_query(PromisedQueryPtr &query);
+  td::Status process_unpin_all_general_forum_topic_messages_query(PromisedQueryPtr &query);
   td::Status process_get_chat_member_query(PromisedQueryPtr &query);
   td::Status process_get_chat_administrators_query(PromisedQueryPtr &query);
   td::Status process_get_chat_member_count_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -837,8 +837,6 @@ class Client final : public WebhookActor::Callback {
 
   static void drop_reply_to_message_in_another_chat(object_ptr<td_api::message> &message);
 
-  void set_message_reply_to_message_id(MessageInfo *message_info, int64 reply_to_message_id);
-
   static td::Slice get_sticker_type(const object_ptr<td_api::StickerType> &type);
 
   static td::Result<object_ptr<td_api::StickerType>> get_sticker_type(td::Slice type);
@@ -874,8 +872,6 @@ class Client final : public WebhookActor::Callback {
                                               const td_api::chatAdministratorRights *rights, ChatType chat_type);
 
   static void json_store_permissions(td::JsonObjectScope &object, const td_api::chatPermissions *permissions);
-
-  void remove_replies_to_message(int64 chat_id, int64 reply_to_message_id, bool only_from_cache);
 
   td::unique_ptr<MessageInfo> delete_message(int64 chat_id, int64 message_id, bool only_from_cache);
 
@@ -1036,9 +1032,6 @@ class Client final : public WebhookActor::Callback {
   td::WaitFreeHashMap<int64, td::unique_ptr<GroupInfo>> groups_;
   td::WaitFreeHashMap<int64, td::unique_ptr<SupergroupInfo>> supergroups_;
   td::WaitFreeHashMap<int64, td::unique_ptr<ChatInfo>> chats_;
-
-  td::FlatHashMap<FullMessageId, td::FlatHashSet<int64>, FullMessageIdHash>
-      reply_message_ids_;  // message -> replies to it
 
   td::FlatHashMap<int32, td::vector<PromisedQueryPtr>> file_download_listeners_;
   td::FlatHashSet<int32> download_started_file_ids_;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -825,7 +825,7 @@ class Client final : public WebhookActor::Callback {
     td::string initial_author_signature;
     td::string initial_sender_name;
     td::string author_signature;
-    int64 reply_to_message_id = 0;
+    object_ptr<td_api::messageReplyToMessage> reply_to_message;
     int64 media_album_id = 0;
     int64 via_bot_user_id = 0;
     object_ptr<td_api::MessageContent> content;
@@ -837,9 +837,13 @@ class Client final : public WebhookActor::Callback {
     mutable bool is_content_changed = false;
   };
 
-  static int64 get_reply_to_message_id(const object_ptr<td_api::message> &message);
+  static int64 get_same_chat_reply_to_message_id(const td_api::messageReplyToMessage *reply_to);
 
-  static void drop_reply_to_message_in_another_chat(object_ptr<td_api::message> &message);
+  static int64 get_same_chat_reply_to_message_id(const object_ptr<td_api::MessageReplyTo> &reply_to);
+
+  static int64 get_same_chat_reply_to_message_id(const object_ptr<td_api::message> &message);
+
+  static void drop_internal_reply_to_message_in_another_chat(object_ptr<td_api::message> &message);
 
   static td::Slice get_sticker_type(const object_ptr<td_api::StickerType> &type);
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -513,7 +513,7 @@ class Client final : public WebhookActor::Callback {
 
   static bool is_local_method(td::Slice method);
 
-  void on_cmd(PromisedQueryPtr query);
+  void on_cmd(PromisedQueryPtr query, bool force = false);
 
   td::Status process_get_me_query(PromisedQueryPtr &query);
   td::Status process_get_my_commands_query(PromisedQueryPtr &query);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -331,7 +331,7 @@ class Client final : public WebhookActor::Callback {
 
   static bool to_bool(td::MutableSlice value);
 
-  static object_ptr<td_api::MessageReplyTo> get_message_reply_to(int64 reply_to_message_id);
+  static object_ptr<td_api::InputMessageReplyTo> get_input_message_reply_to(int64 reply_to_message_id);
 
   static td::Result<object_ptr<td_api::keyboardButton>> get_keyboard_button(td::JsonValue &button);
 

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -238,6 +238,7 @@ class Client final : public WebhookActor::Callback {
   struct UserInfo;
   struct ChatInfo;
   struct BotCommandScope;
+  struct BotUserIds;
 
   enum class AccessRights { Read, ReadMembers, Edit, Write };
 
@@ -332,11 +333,12 @@ class Client final : public WebhookActor::Callback {
 
   static td::Result<object_ptr<td_api::keyboardButton>> get_keyboard_button(td::JsonValue &button);
 
-  td::Result<object_ptr<td_api::inlineKeyboardButton>> get_inline_keyboard_button(td::JsonValue &button);
+  static td::Result<object_ptr<td_api::inlineKeyboardButton>> get_inline_keyboard_button(td::JsonValue &button,
+                                                                                         BotUserIds &bot_user_ids);
 
-  td::Result<object_ptr<td_api::ReplyMarkup>> get_reply_markup(const Query *query);
+  static td::Result<object_ptr<td_api::ReplyMarkup>> get_reply_markup(const Query *query, BotUserIds &bot_user_ids);
 
-  td::Result<object_ptr<td_api::ReplyMarkup>> get_reply_markup(td::JsonValue &&value);
+  static td::Result<object_ptr<td_api::ReplyMarkup>> get_reply_markup(td::JsonValue &&value, BotUserIds &bot_user_ids);
 
   static td::Result<object_ptr<td_api::labeledPricePart>> get_labeled_price_part(td::JsonValue &value);
 
@@ -370,13 +372,17 @@ class Client final : public WebhookActor::Callback {
   static td::Result<td_api::object_ptr<td_api::inlineQueryResultsButton>> get_inline_query_results_button(
       td::MutableSlice value);
 
-  td::Result<object_ptr<td_api::InputInlineQueryResult>> get_inline_query_result(const Query *query);
+  static td::Result<object_ptr<td_api::InputInlineQueryResult>> get_inline_query_result(const Query *query,
+                                                                                        BotUserIds &bot_user_ids);
 
-  td::Result<object_ptr<td_api::InputInlineQueryResult>> get_inline_query_result(td::JsonValue &&value);
+  static td::Result<object_ptr<td_api::InputInlineQueryResult>> get_inline_query_result(td::JsonValue &&value,
+                                                                                        BotUserIds &bot_user_ids);
 
-  td::Result<td::vector<object_ptr<td_api::InputInlineQueryResult>>> get_inline_query_results(const Query *query);
+  static td::Result<td::vector<object_ptr<td_api::InputInlineQueryResult>>> get_inline_query_results(
+      const Query *query, BotUserIds &bot_user_ids);
 
-  td::Result<td::vector<object_ptr<td_api::InputInlineQueryResult>>> get_inline_query_results(td::JsonValue &&value);
+  static td::Result<td::vector<object_ptr<td_api::InputInlineQueryResult>>> get_inline_query_results(
+      td::JsonValue &&value, BotUserIds &bot_user_ids);
 
   struct BotCommandScope {
     object_ptr<td_api::BotCommandScope> scope_;
@@ -1076,11 +1082,13 @@ class Client final : public WebhookActor::Callback {
 
   td::WaitFreeHashMap<int64, td::string> sticker_set_names_;
 
-  int64 cur_temp_bot_user_id_ = 1;
-  td::FlatHashMap<td::string, int64> bot_user_ids_;
-  td::FlatHashSet<td::string> unresolved_bot_usernames_;
-  td::FlatHashMap<int64, int64> temp_to_real_bot_user_id_;
-  td::FlatHashMap<td::string, td::vector<int64>> awaiting_bot_resolve_queries_;
+  struct BotUserIds {
+    int64 default_bot_user_id_ = 0;
+    int64 cur_temp_bot_user_id_ = 1;
+    td::FlatHashMap<td::string, int64> bot_user_ids_;
+    td::FlatHashSet<td::string> unresolved_bot_usernames_;
+  };
+  BotUserIds bot_user_ids_;
 
   struct PendingBotResolveQuery {
     std::size_t pending_resolve_count = 0;
@@ -1089,6 +1097,9 @@ class Client final : public WebhookActor::Callback {
   };
   td::FlatHashMap<int64, PendingBotResolveQuery> pending_bot_resolve_queries_;
   int64 current_bot_resolve_query_id_ = 1;
+
+  td::FlatHashMap<td::string, td::vector<int64>> awaiting_bot_resolve_queries_;
+  td::FlatHashMap<int64, int64> temp_to_real_bot_user_id_;
 
   td::string dir_;
   td::ActorOwn<td::ClientActor> td_client_;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -639,7 +639,10 @@ class Client final : public WebhookActor::Callback {
 
   void on_webhook_closed(td::Status status);
 
-  void do_send_message(object_ptr<td_api::InputMessageContent> input_message_content, PromisedQueryPtr query);
+  void delete_last_send_message_time(td::int64 file_size, double max_delay);
+
+  void do_send_message(object_ptr<td_api::InputMessageContent> input_message_content, PromisedQueryPtr query,
+                       bool force = false);
 
   int64 get_send_message_query_id(PromisedQueryPtr query, bool is_multisend);
 
@@ -1081,6 +1084,8 @@ class Client final : public WebhookActor::Callback {
   td::FlatHashMap<int64, NewCallbackQueryQueue> new_callback_query_queues_;  // sender_user_id -> queue
 
   td::WaitFreeHashMap<int64, td::string> sticker_set_names_;
+
+  td::WaitFreeHashMap<int64, double> last_send_message_time_;
 
   struct BotUserIds {
     int64 default_bot_user_id_ = 0;

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -833,8 +833,6 @@ class Client final : public WebhookActor::Callback {
 
   static int64 get_reply_to_message_id(const object_ptr<td_api::message> &message);
 
-  static void drop_reply_to_message_id(object_ptr<td_api::message> &message);
-
   static void drop_reply_to_message_in_another_chat(object_ptr<td_api::message> &message);
 
   static td::Slice get_sticker_type(const object_ptr<td_api::StickerType> &type);

--- a/telegram-bot-api/Client.h
+++ b/telegram-bot-api/Client.h
@@ -331,6 +331,8 @@ class Client final : public WebhookActor::Callback {
 
   static bool to_bool(td::MutableSlice value);
 
+  static object_ptr<td_api::MessageReplyTo> get_message_reply_to(int64 reply_to_message_id);
+
   static td::Result<object_ptr<td_api::keyboardButton>> get_keyboard_button(td::JsonValue &button);
 
   static td::Result<object_ptr<td_api::inlineKeyboardButton>> get_inline_keyboard_button(td::JsonValue &button,

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -350,7 +350,7 @@ void ClientManager::start_up() {
   parameters_->shared_data_->webhook_db_ = std::move(concurrent_webhook_db);
 
   auto &webhook_db = *parameters_->shared_data_->webhook_db_;
-  for (auto key_value : webhook_db.get_all()) {
+  for (const auto &key_value : webhook_db.get_all()) {
     if (!token_range_(td::to_integer<td::uint64>(key_value.first))) {
       LOG(WARNING) << "DROP WEBHOOK: " << key_value.first << " ---> " << key_value.second;
       webhook_db.erase(key_value.first);

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -230,7 +230,6 @@ void ClientManager::get_stats(td::Promise<td::BufferSlice> promise,
       LOG(INFO) << "Failed to get memory statistics: " << r_mem_stat.error();
     }
 
-    ServerCpuStat::update(td::Time::now());
     auto cpu_stats = ServerCpuStat::instance().as_vector(td::Time::now());
     for (auto &stat : cpu_stats) {
       sb << stat.key_ << "\t" << stat.value_ << '\n';

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -214,7 +214,7 @@ void ClientManager::get_stats(td::Promise<td::BufferSlice> promise,
 
   auto now = td::Time::now();
   auto top_clients = get_top_clients(50, id_filter);
-  sb << stat_.get_description() << '\n';
+  sb << BotStatActor::get_description() << '\n';
   if (id_filter.empty()) {
     sb << "uptime\t" << now - parameters_->start_time_ << '\n';
     sb << "bot_count\t" << clients_.size() << '\n';

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -531,7 +531,7 @@ void ClientManager::raw_event(const td::Event::Raw &event) {
 
 void ClientManager::timeout_expired() {
   send_closure(watchdog_id_, &Watchdog::kick);
-  set_timeout_in(WATCHDOG_TIMEOUT / 2);
+  set_timeout_in(WATCHDOG_TIMEOUT / 10);
 
   double now = td::Time::now();
   if (now > next_tqueue_gc_time_) {

--- a/telegram-bot-api/ClientManager.cpp
+++ b/telegram-bot-api/ClientManager.cpp
@@ -331,7 +331,7 @@ void ClientManager::start_up() {
     }
 
     auto concurrent_binlog =
-        std::make_shared<td::ConcurrentBinlog>(std::move(binlog), SharedData::get_database_scheduler_id());
+        std::make_shared<td::ConcurrentBinlog>(std::move(binlog), SharedData::get_binlog_scheduler_id());
     auto concurrent_tqueue_binlog = td::make_unique<td::TQueueBinlog<td::BinlogInterface>>();
     concurrent_tqueue_binlog->set_binlog(std::move(concurrent_binlog));
     tqueue->set_callback(std::move(concurrent_tqueue_binlog));
@@ -346,7 +346,7 @@ void ClientManager::start_up() {
   // init webhook_db
   auto concurrent_webhook_db = td::make_unique<td::BinlogKeyValue<td::ConcurrentBinlog>>();
   auto status = concurrent_webhook_db->init(parameters_->working_directory_ + "webhooks_db.binlog", td::DbKey::empty(),
-                                            SharedData::get_database_scheduler_id());
+                                            SharedData::get_binlog_scheduler_id());
   LOG_IF(FATAL, status.is_error()) << "Can't open webhooks_db.binlog " << status;
   parameters_->shared_data_->webhook_db_ = std::move(concurrent_webhook_db);
 

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -62,6 +62,35 @@ struct SharedData {
     // the same scheduler as for file GC in Td
     return 2;
   }
+
+  static td::int32 get_client_scheduler_id() {
+    // the thread for ClientManager and all Clients
+    return 4;
+  }
+
+  static td::int32 get_watchdog_scheduler_id() {
+    // the thread for watchdogs
+    return 5;
+  }
+
+  static td::int32 get_slow_incoming_http_scheduler_id() {
+    // the thread for slow incoming HTTP connections
+    return 6;
+  }
+
+  static td::int32 get_slow_outgoing_http_scheduler_id() {
+    // the thread for slow outgoing HTTP connections
+    return 7;
+  }
+
+  static td::int32 get_dns_resolver_scheduler_id() {
+    // the thread for DNS resolving
+    return 8;
+  }
+
+  static td::int32 get_thread_count() {
+    return 9;
+  }
 };
 
 struct ClientParameters {

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -53,11 +53,6 @@ struct SharedData {
     return static_cast<td::int32>(result);
   }
 
-  static td::int32 get_database_scheduler_id() {
-    // the same scheduler as for database in Td
-    return 1;
-  }
-
   static td::int32 get_file_gc_scheduler_id() {
     // the same scheduler as for file GC in Td
     return 2;
@@ -88,8 +83,18 @@ struct SharedData {
     return 8;
   }
 
-  static td::int32 get_thread_count() {
+  static td::int32 get_binlog_scheduler_id() {
+    // the thread for TQueue and webhook binlogs
     return 9;
+  }
+
+  static td::int32 get_webhook_certificate_scheduler_id() {
+    // the thread for webhook certificate processing
+    return 10;
+  }
+
+  static td::int32 get_thread_count() {
+    return 11;
   }
 };
 

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -93,8 +93,13 @@ struct SharedData {
     return 10;
   }
 
-  static td::int32 get_thread_count() {
+  static td::int32 get_statistics_thread_id() {
+    // the thread for CPU usage updating
     return 11;
+  }
+
+  static td::int32 get_thread_count() {
+    return 12;
   }
 };
 

--- a/telegram-bot-api/ClientParameters.h
+++ b/telegram-bot-api/ClientParameters.h
@@ -72,7 +72,7 @@ struct ClientParameters {
   bool local_mode_ = false;
   bool allow_http_ = false;
   bool use_relative_path_ = false;
-  bool no_file_limit_ = true;
+  bool no_file_limit_ = false;
   bool allow_users_ = false;
   bool allow_users_registration_ = false;
   bool stats_hide_sensible_data_ = false;

--- a/telegram-bot-api/HttpServer.h
+++ b/telegram-bot-api/HttpServer.h
@@ -6,6 +6,8 @@
 //
 #pragma once
 
+#include "telegram-bot-api/ClientParameters.h"
+
 #include "td/net/HttpInboundConnection.h"
 #include "td/net/TcpListener.h"
 
@@ -61,13 +63,8 @@ class HttpServer final : public td::TcpListener::Callback {
   }
 
   void accept(td::SocketFd fd) final {
-    auto scheduler_count = td::Scheduler::instance()->sched_count();
-    auto scheduler_id = scheduler_count - 1;
-    if (scheduler_id > 0) {
-      scheduler_id--;
-    }
     td::create_actor<td::HttpInboundConnection>("HttpInboundConnection", td::BufferedFd<td::SocketFd>(std::move(fd)), 0,
-                                                50, 500, creator_(), scheduler_id)
+                                                50, 500, creator_(), SharedData::get_slow_incoming_http_scheduler_id())
         .release();
   }
 

--- a/telegram-bot-api/Query.cpp
+++ b/telegram-bot-api/Query.cpp
@@ -117,7 +117,23 @@ td::StringBuilder &operator<<(td::StringBuilder &sb, const Query &query) {
   sb << "[bot" << td::rpad(query.token().str(), 46, ' ') << "][time:" << padded_time << ']'
      << td::tag("method", td::lpad(query.method().str(), 20, ' '));
   if (!query.args().empty()) {
-    sb << td::oneline(PSLICE() << query.args());
+    sb << '{';
+    for (const auto &arg : query.args()) {
+      sb << '[';
+      if (arg.first.size() > 128) {
+        sb << '<' << arg.first.size() << '>' << td::oneline(arg.first.substr(0, 128)) << "...";
+      } else {
+        sb << td::oneline(arg.first);
+      }
+      sb << ':';
+      if (arg.second.size() > 4096) {
+        sb << '<' << arg.second.size() << '>' << td::oneline(arg.second.substr(0, 4096)) << "...";
+      } else {
+        sb << td::oneline(arg.second);
+      }
+      sb << ']';
+    }
+    sb << '}';
   }
   if (!query.files().empty()) {
     sb << query.files();

--- a/telegram-bot-api/Query.cpp
+++ b/telegram-bot-api/Query.cpp
@@ -43,7 +43,7 @@ Query::Query(td::vector<td::BufferSlice> &&container, td::Slice token, bool is_t
   }
   td::to_lower_inplace(method_);
   start_timestamp_ = td::Time::now();
-  LOG(INFO) << "QUERY: create " << td::tag("ptr", this) << *this;
+  LOG(INFO) << "Query " << this << ": " << *this;
   if (shared_data_) {
     shared_data_->query_count_.fetch_add(1, std::memory_order_relaxed);
     if (method_ != "getupdates") {
@@ -85,7 +85,7 @@ void Query::set_stat_actor(td::ActorId<BotStatActor> stat_actor) {
 
 void Query::set_ok(td::BufferSlice result) {
   CHECK(state_ == State::Query);
-  LOG(INFO) << "QUERY: got ok " << td::tag("ptr", this) << td::tag("text", result.as_slice());
+  LOG(INFO) << "Query " << this << ": " << td::tag("method", method_) << td::tag("text", result.as_slice());
   answer_ = std::move(result);
   state_ = State::OK;
   http_status_code_ = 200;
@@ -93,7 +93,7 @@ void Query::set_ok(td::BufferSlice result) {
 }
 
 void Query::set_error(int http_status_code, td::BufferSlice result) {
-  LOG(INFO) << "QUERY: got error " << td::tag("ptr", this) << td::tag("code", http_status_code)
+  LOG(INFO) << "Query " << this << ": " << td::tag("method", method_) << td::tag("code", http_status_code)
             << td::tag("text", result.as_slice());
   CHECK(state_ == State::Query);
   answer_ = std::move(result);
@@ -115,7 +115,7 @@ td::StringBuilder &operator<<(td::StringBuilder &sb, const Query &query) {
   auto padded_time =
       td::lpad(PSTRING() << td::format::as_time(td::Time::now_cached() - query.start_timestamp()), 10, ' ');
   sb << "[bot" << td::rpad(query.token().str(), 46, ' ') << "][time:" << padded_time << ']'
-     << td::tag("method", td::lpad(query.method().str(), 20, ' '));
+     << td::tag("method", td::lpad(query.method().str(), 25, ' '));
   if (!query.args().empty()) {
     sb << '{';
     for (const auto &arg : query.args()) {

--- a/telegram-bot-api/Query.h
+++ b/telegram-bot-api/Query.h
@@ -38,37 +38,47 @@ class Query final : public td::ListNode {
   td::Slice token() const {
     return token_;
   }
+
   bool is_test_dc() const {
     return is_test_dc_;
   }
+
   td::Slice method() const {
     return method_;
   }
+
   bool has_arg(td::Slice key) const {
     auto it = std::find_if(args_.begin(), args_.end(),
                            [&key](const std::pair<td::MutableSlice, td::MutableSlice> &s) { return s.first == key; });
     return it != args_.end();
   }
+
   td::MutableSlice arg(td::Slice key) const {
     auto it = std::find_if(args_.begin(), args_.end(),
                            [&key](const std::pair<td::MutableSlice, td::MutableSlice> &s) { return s.first == key; });
     return it == args_.end() ? td::MutableSlice() : it->second;
   }
+
   const td::vector<std::pair<td::MutableSlice, td::MutableSlice>> &args() const {
     return args_;
   }
+
   td::Slice get_header(td::Slice key) const {
     auto it = std::find_if(headers_.begin(), headers_.end(),
                            [&key](const std::pair<td::MutableSlice, td::MutableSlice> &s) { return s.first == key; });
     return it == headers_.end() ? td::Slice() : it->second;
   }
+
   const td::HttpFile *file(td::Slice key) const {
     auto it = std::find_if(files_.begin(), files_.end(), [&key](const td::HttpFile &f) { return f.field_name == key; });
     return it == files_.end() ? nullptr : &*it;
   }
+
   const td::vector<td::HttpFile> &files() const {
     return files_;
   }
+
+  td::int64 files_size() const;
 
   td::string get_peer_ip_address() const;
 
@@ -151,8 +161,6 @@ class Query final : public td::ListNode {
   }
 
   td::int64 query_size() const;
-
-  td::int64 files_size() const;
 
   td::int64 files_max_size() const;
 

--- a/telegram-bot-api/Stats.h
+++ b/telegram-bot-api/Stats.h
@@ -147,7 +147,7 @@ class BotStatActor final : public td::Actor {
   }
 
   BotStatActor(const BotStatActor &) = delete;
-  BotStatActor &operator=(const BotStatActor &other) = delete;
+  BotStatActor &operator=(const BotStatActor &) = delete;
   BotStatActor(BotStatActor &&) = default;
   BotStatActor &operator=(BotStatActor &&other) noexcept {
     if (!empty()) {

--- a/telegram-bot-api/Stats.h
+++ b/telegram-bot-api/Stats.h
@@ -9,7 +9,6 @@
 #include "td/actor/actor.h"
 
 #include "td/utils/common.h"
-#include "td/utils/logging.h"
 #include "td/utils/port/Stat.h"
 #include "td/utils/Time.h"
 #include "td/utils/TimedStat.h"
@@ -49,16 +48,10 @@ class ServerCpuStat {
     static ServerCpuStat stat;
     return stat;
   }
-  static void update(double now) {
-    auto r_event = td::cpu_stat();
-    if (r_event.is_error()) {
-      return;
-    }
-    instance().add_event(r_event.ok(), now);
-    LOG(WARNING) << "CPU usage: " << instance().stat_[1].get_stat(now).as_vector()[0].value_;
-  }
 
-  td::string get_description() const;
+  static void update(double now);
+
+  static td::string get_description();
 
   td::vector<StatItem> as_vector(double now);
 
@@ -71,8 +64,6 @@ class ServerCpuStat {
   td::TimedStat<CpuStat> stat_[SIZE];
 
   ServerCpuStat();
-
-  void add_event(const td::CpuStat &stat, double now);
 };
 
 class ServerBotInfo {
@@ -183,7 +174,7 @@ class BotStatActor final : public td::Actor {
 
   td::vector<StatItem> as_vector(double now);
 
-  td::string get_description() const;
+  static td::string get_description();
 
   double get_score(double now);
 

--- a/telegram-bot-api/WebhookActor.cpp
+++ b/telegram-bot-api/WebhookActor.cpp
@@ -691,7 +691,12 @@ void WebhookActor::handle(td::unique_ptr<td::HttpQuery> response) {
 void WebhookActor::start_up() {
   max_loaded_updates_ = max_connections_ * 2;
 
-  next_ip_address_resolve_time_ = last_success_time_ = td::Time::now() - 3600;
+  last_success_time_ = td::Time::now() - 2 * IP_ADDRESS_CACHE_TIME;
+  if (from_db_flag_) {
+    next_ip_address_resolve_time_ = td::Time::now() + td::Random::fast(0, IP_ADDRESS_CACHE_TIME);
+  } else {
+    next_ip_address_resolve_time_ = last_success_time_;
+  }
 
   active_new_connection_flood_.add_limit(0.5, 10);
 

--- a/telegram-bot-api/WebhookActor.cpp
+++ b/telegram-bot-api/WebhookActor.cpp
@@ -724,11 +724,12 @@ void WebhookActor::start_up() {
 
   if (url_.protocol_ != td::HttpUrl::Protocol::Http && !stop_flag_) {
     // asynchronously create SSL context
-    td::Scheduler::instance()->run_on_scheduler(
-        SharedData::get_database_scheduler_id(), [actor_id = actor_id(this), cert_path = cert_path_](td::Unit) mutable {
-          send_closure(actor_id, &WebhookActor::on_ssl_context_created,
-                       td::SslCtx::create(cert_path, td::SslCtx::VerifyPeer::On));
-        });
+    td::Scheduler::instance()->run_on_scheduler(SharedData::get_webhook_certificate_scheduler_id(),
+                                                [actor_id = actor_id(this), cert_path = cert_path_](td::Unit) mutable {
+                                                  send_closure(
+                                                      actor_id, &WebhookActor::on_ssl_context_created,
+                                                      td::SslCtx::create(cert_path, td::SslCtx::VerifyPeer::On));
+                                                });
   }
 
   yield();

--- a/telegram-bot-api/WebhookActor.cpp
+++ b/telegram-bot-api/WebhookActor.cpp
@@ -73,7 +73,7 @@ WebhookActor::WebhookActor(td::ActorShared<Callback> callback, td::int64 tqueue_
 
 WebhookActor::~WebhookActor() {
   td::Scheduler::instance()->destroy_on_scheduler(SharedData::get_file_gc_scheduler_id(), update_map_, queue_updates_,
-                                                  queues_);
+                                                  queues_, ssl_ctx_);
 }
 
 void WebhookActor::relax_wakeup_at(double wakeup_at, const char *source) {

--- a/telegram-bot-api/WebhookActor.cpp
+++ b/telegram-bot-api/WebhookActor.cpp
@@ -47,10 +47,8 @@ WebhookActor::WebhookActor(td::ActorShared<Callback> callback, td::int64 tqueue_
     , fix_ip_address_(fix_ip_address)
     , from_db_flag_(from_db_flag)
     , max_connections_(max_connections)
-    , secret_token_(std::move(secret_token))
-    , slow_scheduler_id_(td::Scheduler::instance()->sched_count() - 2) {
+    , secret_token_(std::move(secret_token)) {
   CHECK(max_connections_ > 0);
-  CHECK(slow_scheduler_id_ > 0);
 
   if (!cached_ip_address.empty()) {
     auto r_ip_address = td::IPAddress::get_ip_address(cached_ip_address);
@@ -230,7 +228,8 @@ td::Status WebhookActor::create_connection(td::BufferedFd<td::SocketFd> fd) {
   auto *conn = connections_.get(id);
   conn->actor_id_ = td::create_actor<td::HttpOutboundConnection>(
       PSLICE() << "Connect:" << id, std::move(fd), std::move(ssl_stream), 0, 50, 60,
-      td::ActorShared<td::HttpOutboundConnection::Callback>(actor_id(this), id), slow_scheduler_id_);
+      td::ActorShared<td::HttpOutboundConnection::Callback>(actor_id(this), id),
+      SharedData::get_slow_outgoing_http_scheduler_id());
   conn->ip_generation_ = ip_generation_;
   conn->event_id_ = {};
   conn->id_ = id;

--- a/telegram-bot-api/WebhookActor.h
+++ b/telegram-bot-api/WebhookActor.h
@@ -177,7 +177,6 @@ class WebhookActor final : public td::HttpOutboundConnection::Callback {
   double last_success_time_ = 0;
   double wakeup_at_ = 0;
   bool last_update_was_successful_ = true;
-  td::int32 slow_scheduler_id_ = -1;
 
   void relax_wakeup_at(double wakeup_at, const char *source);
 

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -165,7 +165,7 @@ int main(int argc, char *argv[]) {
   auto start_time = td::Time::now();
   auto shared_data = std::make_shared<SharedData>();
   auto parameters = std::make_unique<ClientParameters>();
-  parameters->version_ = "6.9.1";
+  parameters->version_ = "6.9.2";
   parameters->shared_data_ = shared_data;
   parameters->start_time_ = start_time;
   auto net_query_stats = td::create_net_query_stats();

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -459,27 +459,22 @@ int main(int argc, char *argv[]) {
   //              << (td::GitInfo::is_dirty() ? "(dirty)" : "") << " started";
   LOG(WARNING) << "Bot API " << parameters->version_ << " server started";
 
-  // +3 threads for Td
-  // one thread for ClientManager and all Clients
-  // one thread for watchdogs
-  // one thread for slow HTTP connections
-  // one thread for DNS resolving
-  const int thread_count = 7;
-  td::ConcurrentScheduler sched(thread_count, cpu_affinity);
+  td::ConcurrentScheduler sched(SharedData::get_thread_count() - 1, cpu_affinity);
 
   td::GetHostByNameActor::Options get_host_by_name_options;
-  get_host_by_name_options.scheduler_id = thread_count;
+  get_host_by_name_options.scheduler_id = SharedData::get_dns_resolver_scheduler_id();
   parameters->get_host_by_name_actor_id_ =
       sched.create_actor_unsafe<td::GetHostByNameActor>(0, "GetHostByName", std::move(get_host_by_name_options))
           .release();
 
-  auto client_manager =
-      sched.create_actor_unsafe<ClientManager>(thread_count - 3, "ClientManager", std::move(parameters), token_range)
-          .release();
+  auto client_manager = sched
+                            .create_actor_unsafe<ClientManager>(SharedData::get_client_scheduler_id(), "ClientManager",
+                                                                std::move(parameters), token_range)
+                            .release();
 
   sched
       .create_actor_unsafe<HttpServer>(
-          thread_count - 3, "HttpServer", http_ip_address, http_port,
+          SharedData::get_client_scheduler_id(), "HttpServer", http_ip_address, http_port,
           [client_manager, shared_data] {
             return td::ActorOwn<td::HttpInboundConnection::Callback>(
                 td::create_actor<HttpConnection>("HttpConnection", client_manager, shared_data));
@@ -489,7 +484,7 @@ int main(int argc, char *argv[]) {
   if (http_stat_port != 0) {
     sched
         .create_actor_unsafe<HttpServer>(
-            thread_count - 3, "HttpStatsServer", http_stat_ip_address, http_stat_port,
+            SharedData::get_client_scheduler_id(), "HttpStatsServer", http_stat_ip_address, http_stat_port,
             [client_manager] {
               return td::ActorOwn<td::HttpInboundConnection::Callback>(
                   td::create_actor<HttpStatConnection>("HttpStatConnection", client_manager));
@@ -498,8 +493,8 @@ int main(int argc, char *argv[]) {
   }
 
   constexpr double WATCHDOG_TIMEOUT = 0.25;
-  auto watchdog_id =
-      sched.create_actor_unsafe<Watchdog>(thread_count - 2, "Watchdog", td::this_thread::get_id(), WATCHDOG_TIMEOUT);
+  auto watchdog_id = sched.create_actor_unsafe<Watchdog>(SharedData::get_watchdog_scheduler_id(), "Watchdog",
+                                                         td::this_thread::get_id(), WATCHDOG_TIMEOUT);
 
   sched.start();
 

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -562,7 +562,7 @@ int main(int argc, char *argv[]) {
     if (now >= start_time + 600) {
       auto guard = sched.get_main_guard();
       send_closure(watchdog_id, &Watchdog::kick);
-      next_watchdog_kick_time = now + WATCHDOG_TIMEOUT / 2;
+      next_watchdog_kick_time = now + WATCHDOG_TIMEOUT / 10;
     }
 
     if (!need_dump_statistics.test_and_set() || now > last_dump_time + 300.0) {

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -556,7 +556,9 @@ int main(int argc, char *argv[]) {
         next_cron_time = now;
       }
       next_cron_time += 1.0;
-      ServerCpuStat::update(now);
+      auto guard = sched.get_main_guard();
+      td::Scheduler::instance()->run_on_scheduler(SharedData::get_statistics_thread_id(),
+                                                  [](td::Unit) { ServerCpuStat::update(td::Time::now()); });
     }
 
     if (now >= start_time + 600) {

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -165,7 +165,7 @@ int main(int argc, char *argv[]) {
   auto start_time = td::Time::now();
   auto shared_data = std::make_shared<SharedData>();
   auto parameters = std::make_unique<ClientParameters>();
-  parameters->version_ = "6.9";
+  parameters->version_ = "6.9.1";
   parameters->shared_data_ = shared_data;
   parameters->start_time_ = start_time;
   auto net_query_stats = td::create_net_query_stats();

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -165,7 +165,7 @@ int main(int argc, char *argv[]) {
   auto start_time = td::Time::now();
   auto shared_data = std::make_shared<SharedData>();
   auto parameters = std::make_unique<ClientParameters>();
-  parameters->version_ = "6.7.1";
+  parameters->version_ = "6.8";
   parameters->shared_data_ = shared_data;
   parameters->start_time_ = start_time;
   auto net_query_stats = td::create_net_query_stats();

--- a/telegram-bot-api/telegram-bot-api.cpp
+++ b/telegram-bot-api/telegram-bot-api.cpp
@@ -165,7 +165,7 @@ int main(int argc, char *argv[]) {
   auto start_time = td::Time::now();
   auto shared_data = std::make_shared<SharedData>();
   auto parameters = std::make_unique<ClientParameters>();
-  parameters->version_ = "6.8";
+  parameters->version_ = "6.9";
   parameters->shared_data_ = shared_data;
   parameters->start_time_ = start_time;
   auto net_query_stats = td::create_net_query_stats();


### PR DESCRIPTION
- Use bot identifier as token for webhook requests.
- Make Client::get_reply_markup static.
- Keep last time when a file was uploaded.
- Improve replies handling.
- Don't track replies by yet unsent messages.
- Don't drop replies to deleted messages.
- Improve processing of new messages.
- Update TDLib to 1.8.15 and support votes by chats in polls.
- Add Chat.emoji_status_expiration_date.
- Support messageStory as empty objects.
- Add unpinAllGeneralForumTopicMessages.
- Improve warnings for old updates.
- Improve threads usage.
- Add dedicated threads for TQueue and webhook databases and webhook certificate processing.
- Use get_json_object_long_field to fetch "amount".
- Use JsonObject member functions to get field values.
- Simplify reply markup parsing.
- Improve logging of big queries.
- Update TDLib to 1.8.16.
- Update version to 6.8.
- Make watchdog timeouts more precise.
- Improve ServerCpuStat.
- Update CPU statistics on a dedicated thread.
- Update TDLib to 1.8.17.
- Explicitly disallow message updates with "channel_chat_created" content.
- Immediately return an error if more than 50 inline query results are provided.
- Improve query logging.
- Update TDLib to 1.8.18.
- Don't update CPU statistics before returning it to avoid synchronous open of "/proc/stat".
- Fail request early if message/caption/explanation text is too long.
- Update TDLib to 1.8.19.
- Support "can_post_stories", "can_edit_stories" and "can_delete_stories" administrator rights.
- Add more fields to WriteAccessAllowed.
- Update version to 6.9.
- Update TDLib and version to 6.9.1.
- Maintain last time when a file was uploaded for all requests.
- Update TDLib to 1.8.20.
- Log skipped updates.
- Update TDLib to 1.8.21.
- Slowly recheck webhook IP addresses after loading them from database.
- Minor improvements.
- Store td_api::messageReplyToMessage in MessageInfo.
- Keep reply to the top thread message for external replies.
- Update version to 6.9.2.
- fix: fix no_file_limit typo
